### PR TITLE
Sort by date field did not work. Error: Unspecified or ambiguous sort…

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -332,7 +332,7 @@ Cloudant.prototype.buildSort = function(mo, model, order) {
 
     if (props[n] && props[n].type === Number)
       n = n.concat(':number');
-    if (props[n] && props[n].type === String)
+    if (props[n] && (props[n].type === String || props[n].type === Date))
       n = n.concat(':string');
     if (n === idName) {
       n = '_id';


### PR DESCRIPTION
When sorting a date field I got the following error:
Unspecified or ambiguous sorttype. Try appending :number or :string to the sort field. checkdate

Solution: add :string to sort expression

After changing this one line of code it works as expected.