### PR TITLE
Lazy connect when booting from swagger generator

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -14,7 +14,15 @@ var _ = require('lodash');
  */
 exports.initialize = function(ds, cb) {
   ds.connector = new Cloudant(ds.settings, ds);
-  if (cb) ds.connector.connect(cb);
+  if (cb) {
+    if (ds.settings.lazyConnect) {
+      process.nextTick(function() {
+        cb();
+      });
+    } else {
+      ds.connector.connect(cb);
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
Connect to strongloop/loopback#2242

When booting app from swagger generator, datasources are setup with ds.lazyConnect = true to avoid connection.