### PR TITLE
Added check for ignoreCase flag on RegExp queries.

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -326,7 +326,9 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
         if (cond.constructor.name === 'RegExp') {
           if (cond.global)
             g.warn('Cloudant {{regex}} syntax does not support global');
-          query[k] = { $regex: cond.source };
+          var expression = cond.source;
+          if (cond.ignoreCase) expression = '(?i)' + expression;
+          query[k] = { $regex: expression };
         } else {
           query[k] = { $regex: cond };
         }

--- a/test/regexp.test.js
+++ b/test/regexp.test.js
@@ -33,6 +33,14 @@ describe('cloudant regexp', function() {
       done();
     });
   });
+  it('find all foos that are case-insensitive B', function(done) {
+    Foo.find({where: {bar: {regexp: '/B/i'}}}, function(err, entries) {
+      console.log (entries);
+      entries.should.have.lengthOf(1);
+      entries[0].bar.should.equal('b');
+      done();
+    });
+  });
   it('find all foos like b', function(done) {
     Foo.find({where: {bar: {like: 'b'}}}, function(err, entries) {
       console.log (entries);

--- a/test/regexp.test.js
+++ b/test/regexp.test.js
@@ -25,7 +25,7 @@ describe('cloudant regexp', function() {
       done();
     });
   });
-  it('find all foos begining with b', function(done) {
+  it('find all foos beginning with b', function(done) {
     Foo.find({where: {bar: {regexp: '^b'}}}, function(err, entries) {
       console.log (entries);
       entries.should.have.lengthOf(1);


### PR DESCRIPTION
This is a fix for #25.
`Cloudant.prototype.buildSelector` now parses the `ignoreCase` from RegExp objects and provides it to the `$regex` operator in PCRE format by prepending `(?i)` to the expression.