### PR TITLE
Update cloudant.js

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -54,6 +54,11 @@ function Cloudant(settings, ds) {
     password: settings.password,
   };
   this.cloudant = Driver(this.creds);
+  
+  if (settings.proxy) {
+    this.cloudant.config.requestDefaults.proxy = settings.proxy;
+  }
+
   this.pool = {};
 }
 


### PR DESCRIPTION
I would like to add the ability to have the cloudant use a proxy agent.  The code i have added allows me to set a basic authenticated proxy on the http request.