### PR TITLE
replaceOrCreate should create new instance if id provided

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -604,29 +604,39 @@ Cloudant.prototype.replaceOrCreate = function replaceOrCreate(
   var self = this;
   var idName = self.idName(model);
   var mo = self.selectModel(model);
-
   var id = data[idName];
-  if (id) {
-    self.getCurrentRevision(model, id, function(err, rev) {
-      if (err) return cb(err);
-      if (rev) data._rev = rev;
-      self._insert(model, data, function(err) {
+
+  // Check if data exist first to avoid
+  // running getCurrentRevision() again an nonexistent instance
+  var where = {}; where[idName] = id;
+  var dataExist;
+
+  self.count(model, where, {}, function(err, cnt) {
+    if (err) return cb(err);
+    dataExist = cnt === 1 ? true : false;
+
+    if (id && dataExist === true) {
+      self.getCurrentRevision(model, id, function(err, rev) {
+        if (err) return cb(err);
+        if (rev) data._rev = rev;
+        self._insert(model, data, function(err) {
+          if (err) return cb(err);
+          mo.db.get(id, function(err, doc) {
+            if (err) return cb(err);
+            cb(err, self.fromDB(model, mo, doc), {isNewInstance: !rev});
+          });
+        });
+      });
+    } else {
+      self.create(model, data, options, function(err, id) {
         if (err) return cb(err);
         mo.db.get(id, function(err, doc) {
           if (err) return cb(err);
-          cb(err, self.fromDB(model, mo, doc), {isNewInstance: !rev});
+          cb(err, self.fromDB(model, mo, doc), {isNewInstance: true});
         });
       });
-    });
-  } else {
-    self.create(model, data, options, function(err, id) {
-      if (err) return cb(err);
-      mo.db.get(id, function(err, doc) {
-        if (err) return cb(err);
-        cb(err, self.fromDB(model, mo, doc), {isNewInstance: true});
-      });
-    });
-  }
+    };
+  });
 };
 
 /**

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -68,6 +68,36 @@ describe('cloudant connector', function() {
           });
         };
       });
+    it('should create new instance if id provided', function(done) {
+      Product.replaceOrCreate({
+        id: 2,
+        name: 'newInstance',
+        price: 100,
+      }, function(err, product) {
+        if (err) return done(err);
+        verifyCreatedData(product);
+      });
+
+      function verifyCreatedData(data) {
+        // Verify callback data
+        data.id.should.be.equal('2');
+        data.name.should.be.equal('newInstance');
+        data.price.should.be.equal(100);
+
+        // Verify DB data
+        verifyDBData(data.id);
+      };
+
+      function verifyDBData(id) {
+        Product.findById(id, function(err, data) {
+          if (err) return done(err);
+          data.id.should.be.equal('2');
+          data.name.should.be.equal('newInstance');
+          data.price.should.be.equal(100);
+          done();
+        });
+      };
+    });
   });
 
   describe('replaceById', function() {


### PR DESCRIPTION
Connect to https://github.com/strongloop-internal/scrum-loopback#991

Scenario:
Without fix in this pr
```js
MyModel.replaceOrCreate({
  id: 'myid', // id provided 
  name: 'myname',
}, function(err, result){...});
```
will fail if the instance doesn't exist in database.
The current code doesn't check instance exist before do the [`getRevision()`](https://github.com/strongloop/loopback-connector-cloudant/blob/master/lib/cloudant.js#L610) , which cannot run against an nonexistent instance.

Details see: https://github.com/strongloop-internal/scrum-loopback/issues/991#issuecomment-256077756