### PR TITLE
Explain uncaught url error in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ password  | String | Cloudant password
 url       | String | Cloudant URL containing both username and password
 modelIndex | String | Specify the model name to document mapping, defaults to 'loopback\_\_model\_\_name'
 
+**NOTE: Please be aware that the url will override username/password.**
 
 ### Model Specific Configuration
 


### PR DESCRIPTION
Connect to strongloop/loopback-connector-cloudant#18

Add explanation to warn users an invalid url string will result in uncaught error and fail their app.

PTAL @strongloop/squad-apex . Thanks.