### PR TITLE
cloudant: allow passthrough of settings

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -41,6 +41,8 @@ exports.initialize = function(ds, cb) {
  * @constructor
  */
 function Cloudant(settings, ds) {
+  // Injection for tests
+  var CloudantDriver = settings.Driver || Driver;
   debug('Cloudant constructor settings: %j', settings);
   Connector.call(this, 'cloudant', settings);
   this.debug = settings.debug || debug.enabled;
@@ -49,11 +51,14 @@ function Cloudant(settings, ds) {
     throw new Error('Invalid settings: "url" OR "username"' +
     ' AND "password" required');
   }
-  this.creds = settings.url || {
-    account: settings.username,
-    password: settings.password,
-  };
-  this.cloudant = Driver(this.creds);
+
+  this.options = _.merge({}, settings);
+  // If settings.url is not set, then setup account/password props.
+  if (!this.options.url) {
+    this.options.account = settings.username;
+    this.options.password = settings.password;
+  }
+  this.cloudant = CloudantDriver(this.options);
   this.pool = {};
 }
 

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var Cloudant = require('../lib/cloudant');
+var _ = require('lodash');
 var should = require('should');
 var describe = require('./describe');
 var db, Product;
@@ -109,5 +111,42 @@ describe('cloudant connector', function() {
           });
         };
       });
+  });
+});
+
+describe('cloudant constructor', function() {
+  it('should allow passthrough of properties in the settings object',
+    function() {
+      var ds = getDataSource();
+      ds.settings = ds.settings || {};
+      var result = {};
+      ds.settings.Driver = function(options) {
+        result = options;
+      };
+      ds.settings.foobar = {
+        foo: 'bar',
+      };
+      ds.settings.plugin = 'whack-a-mole';
+      var connector = Cloudant.initialize(ds, function(err) {
+        should.not.exist(err);
+        should.exist(result.foobar);
+        result.foobar.foo.should.be.equal('bar');
+        result.plugin.should.be.equal(ds.settings.plugin);
+      });
+    });
+
+  it('should pass the url as an object property', function() {
+    var ds = getDataSource();
+    ds.settings = ds.settings || {};
+    var result = {};
+    ds.settings.Driver = function(options) {
+      result = options;
+    };
+    ds.settings.url = 'https://totallyfakeuser:fakepass@definitelynotreal.cloudant.com';
+    var connector = Cloudant.initialize(ds, function() {
+      // The url will definitely cause a connection error, so ignore.
+      should.exist(result.url);
+      result.url.should.equal(ds.settings.url);
+    });
   });
 });


### PR DESCRIPTION
### Description
Arbitrary properties of the settings object will now be passed
to the driver to allow configuration of nodejs-cloudant settings.

#### Related issues
#56

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
