### PR TITLE
Fix updateAll for model instance as input

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -514,6 +514,8 @@ Cloudant.prototype.updateAttributes = function(model, id, data, options, cb) {
   var mo = self.selectModel(model);
   mo.db.get(id, function(err, doc) {
     if (err) return cb(err, doc);
+    
+    data = getPlainJSONData.call(self, model, data);
     _.merge(doc, data);
     self.create(model, doc, options, function(err) {
       cb(err, self.fromDB(model, mo, doc));
@@ -521,6 +523,19 @@ Cloudant.prototype.updateAttributes = function(model, id, data, options, cb) {
   });
 };
 
+/**
+ * If input is a model instance, convert to a plain JSON object
+ * The input would be a model instance when the request is made from
+ * REST endpoint as remoting converts it to model if endpoint expects a
+ * model instance
+ */
+
+function getPlainJSONData(model, data) {
+  if (this._models[model] && data instanceof this._models[model].model) {
+    return data.toJSON();
+  }
+  return data;
+}
 /**
  * Update if the model instance exists with the same id or create a
  * new instance
@@ -570,6 +585,9 @@ Cloudant.prototype.updateAll = function updateAll(model, where,
     if (docs.length === 0) {
       return cb(null, {count: 0});
     }
+
+    data = getPlainJSONData.call(self, model, data);
+
     for (var i = 0; i < docs.length; i++) {
       _.merge(docs[i], data);
     }

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -514,7 +514,7 @@ Cloudant.prototype.updateAttributes = function(model, id, data, options, cb) {
   var mo = self.selectModel(model);
   mo.db.get(id, function(err, doc) {
     if (err) return cb(err, doc);
-    
+
     data = getPlainJSONData.call(self, model, data);
     _.merge(doc, data);
     self.create(model, doc, options, function(err) {

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -113,13 +113,13 @@ describe('cloudant connector', function() {
       });
   });
 
-  describe('updateAll', function() {
+  describe('updateAll and updateAttributes', function() {
     var productInstance;
-    beforeEach('create Product', function(done){
+    beforeEach('create Product', function(done) {
       Product.create({
         id: 1,
         name: 'bread',
-        price: 100
+        price: 100,
       }, function(err, product) {
         if (err) return done(err);
         productInstance = product;
@@ -127,10 +127,17 @@ describe('cloudant connector', function() {
       });
     });
 
+    afterEach(function(done) {
+      Product.destroy({id: 1}, function(err) {
+        if (err) return done(err);
+        done();
+      });
+    });
+
     it('accepts loopback model instance as input data for update',
       function(done) {
         productInstance.setAttribute('name', 'butter');
-        Product.updateAll({ id: '1' }, productInstance, function(err, res) {
+        Product.updateAll({id: '1'}, productInstance, function(err, res) {
           if (err) return done(err);
 
           Product.findById('1', function(err, prod) {
@@ -138,7 +145,7 @@ describe('cloudant connector', function() {
             done();
           });
         });
-    });
+      });
   });
 });
 

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -112,6 +112,34 @@ describe('cloudant connector', function() {
         };
       });
   });
+
+  describe('updateAll', function() {
+    var productInstance;
+    beforeEach('create Product', function(done){
+      Product.create({
+        id: 1,
+        name: 'bread',
+        price: 100
+      }, function(err, product) {
+        if (err) return done(err);
+        productInstance = product;
+        done();
+      });
+    });
+
+    it('accepts loopback model instance as input data for update',
+      function(done) {
+        productInstance.setAttribute('name', 'butter');
+        Product.updateAll({ id: '1' }, productInstance, function(err, res) {
+          if (err) return done(err);
+
+          Product.findById('1', function(err, prod) {
+            prod.name.should.equal('butter');
+            done();
+          });
+        });
+    });
+  });
 });
 
 describe('cloudant constructor', function() {


### PR DESCRIPTION
invoking updateAll() with input data in loopback
model instance format was causing failures as
it was not converted to canonical presentation.

This fix resolves it by checking if input data
is a model instance and if it is, convert it to
a plain JSON object for update.

Fixes #71

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
