### PR TITLE
Append field type for nested properties

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -366,7 +366,7 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
 
 Cloudant.prototype.buildSort = function(mo, model, order) {
   debug('Cloudant.prototype.buildSort %j', order);
-  var obj;
+  var field, fieldType, nestedFields, obj;
   var sort = [];
   var props = mo.mo.properties;
   var idName = this.idName(model);
@@ -382,10 +382,26 @@ Cloudant.prototype.buildSort = function(mo, model, order) {
     var k = order[i];
     var m = k.match(/\s+(A|DE)SC$/);
     var n = k.replace(/\s+(A|DE)SC$/, '').trim();
+    if (typeof n === 'string') {
+      nestedFields = n.split('.');
+    }
 
-    if (props[n] && props[n].type === Number)
+    if (nestedFields.length > 1) {
+      var begin = props;
+      for (var f in nestedFields) {
+        field = nestedFields[f];
+        if (begin[field] && typeof begin[field] === 'function')
+          fieldType = begin[field];
+        if (begin[field] && typeof begin[field] === 'object')
+          begin = begin[field];
+      }
+    } else {
+      fieldType = props[n].type;
+    }
+
+    if (fieldType === Number)
       n = n.concat(':number');
-    if (props[n] && (props[n].type === String || props[n].type === Date))
+    if (fieldType === String || fieldType === Date)
       n = n.concat(':string');
     if (n === idName) {
       n = '_id';


### PR DESCRIPTION
Connect to strongloop/loopback-connector-cloudant#75

Append field type for nested properties. Before the pr it only applies to first level property.
Test case is in juggler https://github.com/strongloop/loopback-datasource-juggler/pull/1239/files#diff-8fae24fa21c82e23f7f43ccdae4fcf90R635
