### PR TITLE
Build selector with array type data

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -365,6 +365,39 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
     } else {
       query[k] = cond;
     }
+    cond = query[k];
+
+    var filterArray = buildFilterArr(k, mo.mo.properties);
+    delete query[k];
+    Object.assign(query, filterArray);
+
+    function buildFilterArr(k, props) {
+      var fields = k.split('.');
+      var l = fields.length;
+      var begin = props;
+      for (var f in fields) {
+        var field = fields[f];
+        if (begin[field] && isArray(begin[field])) {
+          var endk = fields.slice(Number(f) + 1, l).join('.');
+          var begink = fields.slice(0, Number(f) + 1).join('.');
+          var elemCond = buildFilterArr(endk, begin[field]);
+          var result = {};
+          result[begink] = {'$elemMatch': elemCond};
+          return result;
+        }
+        if (f == l - 1) {
+          var res = {};
+          res[k] = cond;
+          return res;
+        }
+        begin = begin[field];
+      };
+    };
+    function isArray(elem) {
+      if (elem.type && elem.type.constructor.name === 'Array') return true;
+      if (elem.constructor.name === 'Array') return true;
+      return false;
+    };
   });
   if (containsRegex && !query['_id']) {
     query['_id'] = {


### PR DESCRIPTION
connect to strongloop/loopback-connector-cloudant#78

When filter against array data, e.g. `friends.name` in the example below is `Array`, the current query is:
 `{where: {friends.name: 'Ringo Starr'}}`
while the *right query* is: 
`{where: {friends: {$elemMatch: {name: 'Ringo Starr'}}}}`

This PR wraps array filter with `$elemMatch`.

---

Test case is in juggler: https://github.com/strongloop/loopback-datasource-juggler/pull/1239/files#diff-8fae24fa21c82e23f7f43ccdae4fcf90R646