### PR TITLE
Make equality operator as query basis when query contains regex

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -295,6 +295,7 @@ function findRecursive(mo, query, docs, include, cb) {
 
 Cloudant.prototype.buildSelector = function(model, mo, where) {
   var self = this;
+  var containsRegex = false;
   var query = (mo.modelSelector || {});
   if (mo.modelSelector === null) {
     query[mo.modelView] = model;
@@ -341,8 +342,10 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
         query[k] = {$ne: cond};
       } else if (spec === 'like') {
         query[k] = {$regex: cond};
+        containsRegex = true;
       } else if (spec === 'nlike') {
         query[k] = {$regex: '[^' + cond + ']'};
+        containsRegex = true;
       } else if (spec === 'regexp') {
         if (cond.constructor.name === 'RegExp') {
           if (cond.global)
@@ -350,8 +353,10 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
           var expression = cond.source;
           if (cond.ignoreCase) expression = '(?i)' + expression;
           query[k] = {$regex: expression};
+          containsRegex = true;
         } else {
           query[k] = {$regex: cond};
+          containsRegex = true;
         }
       } else {
         query[k] = {};
@@ -361,6 +366,11 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
       query[k] = cond;
     }
   });
+  if (containsRegex && !query['_id']) {
+    query['_id'] = {
+      '$gt': null,
+    };
+  }
   return query;
 };
 


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-connector-cloudant/issues/77

`$regex` cannot be a basis of query, have to make basis a equality operator to get `$regex` applied.

In this pr, whenever a query with `$regex` is built and there is no condition on `_id`, add `{ "_id": { "$gt": null }}` to the query

---

Test case in juggler: https://github.com/strongloop/loopback-datasource-juggler/pull/1239