### PR TITLE
Support nested property filter

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -374,7 +374,105 @@ Cloudant.prototype.buildSelector = function(model, mo, where) {
     } else {
       query[k] = cond;
     }
+    var filterWithArray = buildFilterArr(k, mo.mo.properties);
+
+    // unfold the string filter to nested object
+    // e.g. {'address.tags.$elemMatch.tag': 'business'} =>
+    // {address: {tags: {$elemMatch: {tag: 'business'}}}}
+    if (typeof filterWithArray === 'string') {
+      var kParser = filterWithArray.split('.');
+      if (kParser.length > 1) {
+        query[kParser.shift()] = buildUnfold(kParser);
+      }
+      function buildUnfold(props) {
+        var obj = {};
+        if (props.length === 1) {
+          obj[props[0]] = query[k];
+          return obj;
+        }
+        obj[props.shift()] = buildUnfold(props);
+        return obj;
+      }
+    } else {
+      query[filterWithArray] = query[k];
+    }
+
+    delete query[k];
+    function buildFilterArr(k, props) {
+      // return original k if
+      // k is not a String
+      // OR there is no properties
+      // OR k is not a nested property
+      if (typeof k !== 'string' || !props) return k;
+      var fields = k.split('.');
+      var len = fields.length;
+      if (len <= 1) return k;
+
+      var newFields = [];
+      var currentProperty = props;
+      var field = '';
+      var propIsArr = false;
+      var propIsObjWithTypeArr = false;
+      for (var i = 0; i < len; i++) {
+        if (propIsArr) {
+          // when Array.isArray(property) is true
+          currentProperty = currentProperty.filter(containsField);
+          if (currentProperty.length < 1) {
+            field = null;
+          } else {
+            currentProperty = currentProperty[0];
+            field = currentProperty[fields[i]];
+          }
+          function containsField(obj) {
+            return obj.hasOwnProperty(fields[i]);
+          };
+          // reset the flag
+          propIsArr = false;
+        } else if (propIsObjWithTypeArr) {
+          // when property is an Object but its type is Array
+          // e.g. my_prop: {
+          //  type: 'array',
+          //  0: {nestedprop1: 'string'},
+          //  1: {nestedprop2: 'number'}
+          // }
+          field = null;
+          for (var property in currentProperty) {
+            if (property === 'type') continue;
+            if (currentProperty[property].hasOwnProperty(fields[i])) {
+              currentProperty = currentProperty[property];
+              field = currentProperty[fields[i]];
+              break;
+            }
+          }
+          // reset the flag
+          propIsObjWithTypeArr = false;
+        } else {
+          field = currentProperty[fields[i]];
+        }
+        // if a nested field doesn't exist, return k
+        // therefore if $elemMatch provided we don't add anything
+        if (!field) return k;
+
+        newFields.push(fields[i]);
+        if (isArray(field)) newFields.push('$elemMatch');
+        currentProperty = field;
+      };
+      function isArray(elem) {
+        if (Array.isArray(elem)) {
+          propIsArr = true;
+          return true;
+        }
+        if (typeof elem === 'object' &&
+          (Array.isArray(elem.type) || elem.type === 'Array')) {
+          propIsObjWithTypeArr = true;
+          return true;
+        }
+        return false;
+      }
+      return newFields.join('.');
+    }
   });
+
   if (containsRegex && !query['_id']) {
     query['_id'] = {
       '$gt': null,
@@ -409,10 +507,13 @@ Cloudant.prototype.buildSort = function(mo, model, order) {
       var begin = props;
       for (var f in nestedFields) {
         field = nestedFields[f];
-        if (begin[field] && typeof begin[field] === 'function')
-          fieldType = begin[field];
-        if (begin[field] && typeof begin[field] === 'object')
+        // Continue the nested type search only when
+        // current property is an object
+        if (begin[field] && typeof begin[field] === 'object') {
           begin = begin[field];
+        } else if (begin[field]) {
+          fieldType = begin[field];
+        }
       }
     } else {
       fieldType = props[n].type;
@@ -420,10 +521,18 @@ Cloudant.prototype.buildSort = function(mo, model, order) {
 
     if (fieldType === Number)
       n = n.concat(':number');
-    if (fieldType === String || fieldType === Date)
+    if (isString(fieldType) || isDate(fieldType))
       n = n.concat(':string');
     if (n === idName) {
       n = '_id';
+    }
+    function isString(type) {
+      if (type === String || type === 'string' || type === 'String')
+        return true;
+    }
+    function isDate(type) {
+      if (type === Date || type === 'date' || type === 'Date')
+        return true;
     }
 
     if (m && m[1] === 'DE') {
@@ -797,9 +906,10 @@ Cloudant.prototype.autoupdate = function(models, cb) {
  * @param {Function} [cb] The callback function
  */
 Cloudant.prototype.automigrate = function(models, cb) {
-  debug('Cloudant.prototype.automigrate %j', models);
+  debug('Cloudant.prototype.automigrate models %j', models);
   var self = this;
   async.eachSeries(models, function(model, cb2) {
+    debug('Cloudant.prototype.automigrate model %j', model);
     var mo = self.selectModel(model, true);
     self.updateIndex(mo, model, cb2);
   }, function(err) {
@@ -838,7 +948,7 @@ Cloudant.prototype.updateIndex = function(mo, modelName, cb) {
     },
   };
   /* eslint-enable camelcase */
-
+  debug('Cloudant.prototype.updateIndex modelName %j', modelName);
   if (mo.modelSelector === null) {
     idx.index.selector[mo.modelView] = modelName;
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha -G --timeout 10000",
+    "test": "mocha -G --timeout 40000",
     "posttest": "npm run lint"
   },
   "dependencies": {

--- a/test/init.js
+++ b/test/init.js
@@ -10,10 +10,16 @@ module.exports = require('should');
 var DataSource = require('loopback-datasource-juggler').DataSource;
 
 var config = {
+  url: process.env.CLOUDANT_URL,
   username: process.env.CLOUDANT_USERNAME,
   password: process.env.CLOUDANT_PASSWORD,
   database: process.env.CLOUDANT_DATABASE,
+  plugin: 'retry',
+  retryAttempts: 10,
+  retryTimeout: 50,
 };
+
+console.log('env config ', config);
 
 global.config = config;
 
@@ -22,7 +28,6 @@ global.getDataSource = global.getSchema = function(customConfig) {
   db.log = function(a) {
     console.log(a);
   };
-
   return db;
 };
 


### PR DESCRIPTION
### Description


#### Related issues

Parent issue: strongloop/loopback#517
Sub-issue in cloudant:
- support array type: https://github.com/strongloop/loopback-connector-cloudant/issues/78
- append sorting data type: https://github.com/strongloop/loopback-connector-cloudant/issues/75
pr for issue#78 is reverted because the algorithm need redesign.

This pr includes implementation of issue#78 and fix for issue#75 
Related test cases in juggler: https://github.com/strongloop/loopback-datasource-juggler/blob/master/test/basic-querying.test.js#L602

#### Background
Support array type: 
  - given a nested field like `field1.field2.field3.field4`, cloudant searches datatype for each field, and insert a `$elemMatch` after if it's an array. e.g. if field2 is an array, the new field will be `field1.field2.$elemMatch.field3.field4`.
  - cloudant db only takes in json format selector when $elemMatch included, so connector unfolds string field to a json one if it's a nested property.
  - the algorithm ensures that in the middle if any datatype is not defined in modelDef or the searching type is `undefined`, user can still provide a complete cloudant selector in query and the request will send the original query. 

Append sorting data type:
  - we assume the nested sorting field doesn't contain array type.

#### Test scenarios(used when verify story)

Check https://gist.github.com/jannyHou/cae4d0b88525b47289a83c11e96b453b

CI is now failing due to connection failed. Related test cases pass on local.