### PR TITLE
Use define function in loopback-connector

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -874,19 +874,6 @@ Cloudant.prototype.selectModel = function(model, migrate) {
 };
 
 /**
- * Hook to be called by DataSource for defining a model
- *
- * @param {Object} modelDefinition The model definition
- */
-Cloudant.prototype.define = function(modelDefinition) {
-  var modelName = modelDefinition.model.modelName;
-  modelDefinition.settings = modelDefinition.settings || {};
-  this._models[modelName] = modelDefinition;
-  var mo = this.selectModel(modelName, true);
-  this.updateIndex(mo, modelName);
-};
-
-/**
  * Perform autoupdate for the given models. It basically calls db.index()
  *
  * @param {String[]} [models] A model name or an array of model names. If not
@@ -900,8 +887,15 @@ Cloudant.prototype.autoupdate = function(models, cb) {
 
 /**
  * Perform automigrate for the given models.
+ * Notes: Cloudant stores a Model as a design doc in database,
+ * `ddoc` is the doc's _id, auto-generated as 'lb-index-ddoc' + modelName,
+ * `name` is the index name, auto-generated as 'lb-index' + modelName.
+ * It does NOT store properties in the doc, which makes autoupdate actually
+ * does the same thing as automigrate.
+ * It does NOT destroy previous model instances if model exists, user needs
+ * to manually destroy them if necessary.
  *
- * @param {String[]} [models] A model name or an array of model names. If not
+ * @param {String|String[]} [models] A model name or an array of model names. If not
  * present, apply to all models
  * @param {Function} [cb] The callback function
  */
@@ -948,7 +942,9 @@ Cloudant.prototype.updateIndex = function(mo, modelName, cb) {
     },
   };
   /* eslint-enable camelcase */
-  debug('Cloudant.prototype.updateIndex modelName %j', modelName);
+  var indexView = util.inspect(idx, 4);
+  debug('Cloudant.prototype.updateIndex -- modelName %s, idx %s', modelName,
+    indexView);
   if (mo.modelSelector === null) {
     idx.index.selector[mo.modelView] = modelName;
   }

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Node module: loopback-connector-cloudant
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+var db, Foo, Bar;
+
+describe('cloudant imported features', function() {
+  before(function() {
+    require('./init.js');
+  });
+  it('automigrates models attached to db', function(done) {
+    db = getSchema();
+    Foo = db.define('Foo', {
+      name: {type: String},
+    });
+    Bar = db.define('Bar', {
+      id: {type: Number, index: true},
+    });
+    db.automigrate(function verifyMigratedModel(err) {
+      if (err) return done(err);
+      Foo.create({name: 'foo'}, function(err, r) {
+        if (err) return done(err);
+        r.should.not.be.empty();
+        r.name.should.equal('foo');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description


#### Related issues

strongloop/loopback-connector-cloudant#92

cloudant has its own `define` function that overrides the one in loopback-connector. It doesn't only add a model to datasource's `_model` object, but also **update** the index, which is exactly what `automigrate` does.

I remove `define` function in this PR because in loopback-datasource-juggler and other loopback components like loopback-boot, `define` is used as a sync function, while update index in cloudant is an async function. https://github.com/strongloop/loopback-connector-cloudant/issues/92 and https://github.com/strongloop/loopback-connector-cloudant/issues/93 are caused by this.

This will be a breaking change since user will have to call `db.automigrate` to migrate their models to database, cloudant won't automatically update the index in model's "define" phase.



#### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
