### PR TITLE
Fix sort query builder

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -520,7 +520,7 @@ Cloudant.prototype.buildSort = function(mo, model, order) {
         }
       }
     } else {
-      fieldType = props[n].type;
+      fieldType = props[n] && props[n].type;
     }
 
     if (fieldType === Number)

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -262,6 +262,8 @@ describe('cloudant connector', function() {
       });
       it('returns result when sorting type provided - missing first level' +
         'property', function(done) {
+        // Similar test case exist in juggler, but since it takes time to
+        // recover them, I temporarily add it here
         CustomerSimple.find({where: {'address.state': 'CA'},
           order: 'missingProperty:string'}, function(err, customers) {
           if (err) return done(err);

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -260,17 +260,31 @@ describe('cloudant connector', function() {
             done();
           });
       });
-      it('returns result when sorting type provided', function(done) {
+      it('returns result when sorting type provided - missing first level' +
+        'property', function(done) {
         CustomerSimple.find({where: {'address.state': 'CA'},
-        order: 'address.city:string DESC'},
-          function(err, customers) {
-            if (err) return done(err);
-            customers.length.should.be.equal(2);
-            customers[0].address.city.should.be.eql('San Mateo');
-            customers[1].address.city.should.be.eql('San Jose');
-            done();
-          });
+          order: 'missingProperty:string'}, function(err, customers) {
+          if (err) return done(err);
+          customers.length.should.be.equal(2);
+          var expected1 = ['San Mateo', 'San Jose'];
+          var expected2 = ['San Jose', 'San Mateo'];
+          var actual = customers.map(function(c) { return c.address.city; });
+          should(actual).be.oneOf(expected1, expected2);
+          done();
+        });
       });
+      it('returns result when sorting type provided - nested property',
+        function(done) {
+          CustomerSimple.find({where: {'address.state': 'CA'},
+            order: 'address.city:string DESC'},
+            function(err, customers) {
+              if (err) return done(err);
+              customers.length.should.be.equal(2);
+              customers[0].address.city.should.be.eql('San Mateo');
+              customers[1].address.city.should.be.eql('San Jose');
+              done();
+            });
+        });
     });
     describe('defined in modelDef', function() {
       it('returns result when complete query of' +

--- a/test/maxrows.test.js
+++ b/test/maxrows.test.js
@@ -9,6 +9,7 @@ var should = require('should');
 var db, Thing;
 
 describe('cloudant max rows', function() {
+  this.timeout(70000);
   var Foo;
   var N = 201;
   before(function(done) {

--- a/test/maxrows.test.js
+++ b/test/maxrows.test.js
@@ -9,6 +9,8 @@ var should = require('should');
 var db, Thing;
 
 describe('cloudant max rows', function() {
+  // This test suite creates large number of data,
+  // require more time to complete data cleanUp
   this.timeout(70000);
   var Foo;
   var N = 201;


### PR DESCRIPTION
connect to strongloop/loopback-connector-cloudant#33
### Description
- [x] Bug

The sort query builder doesn't check first level property exist when it searches for its type.

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
