### PR TITLE
autoupdate and automigrate fix

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -969,7 +969,8 @@ Cloudant.prototype.automigrate = function(models, cb) {
 
 /**
   * Check if the models exist
-  * @param {String|String[]} [models] A model name or an array of model names. * If not present, apply to all models
+  * @param {String|String[]} [models] A model name or an array of model names.
+  * If not present, apply to all models
   * @param {Function} [cb] The callback function
   */
 

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -926,7 +926,7 @@ Cloudant.prototype.autoupdate = function(models, cb) {
  * `ddoc` is the doc's _id, auto-generated as 'lb-index-ddoc' + modelName,
  * `name` is the index name, auto-generated as 'lb-index' + modelName.
  * It does NOT store properties in the doc.
- * `automigrate` one model destroys data if that model already exists.
+ * `automigrate` destroys model data if the model exists.
  * @param {String|String[]} [models] A model name or an array of model names.
  * If not present, apply to all models
  * @param {Function} [cb] The callback function
@@ -934,15 +934,31 @@ Cloudant.prototype.autoupdate = function(models, cb) {
 Cloudant.prototype.automigrate = function(models, cb) {
   debug('Cloudant.prototype.automigrate models %j', models);
   var self = this;
+  var existingModels = [];
   async.series([
+    function(callback) {
+      checkExistingModels(callback);
+    },
     function(callback) {
       destroyData(callback);
     },
     function(callback) {
       self.autoupdate(models, callback);
     }], cb);
+  function checkExistingModels(checkCb) {
+    async.eachSeries(models, function(model, cb1) {
+      self.isActual(model, function(err, exist) {
+        if (err) return cb1(err);
+        if (exist) existingModels.push(model);
+        cb1();
+      });
+    }, function(err) {
+      debug('Cloudant.prototype.automigrate checkExistingModels %j', err);
+      checkCb(err);
+    });
+  };
   function destroyData(destroyCb) {
-    async.eachSeries(models, function(model, cb2) {
+    async.eachSeries(existingModels, function(model, cb2) {
       self.destroyAll(model, {}, {}, cb2);
     }, function(err) {
       debug('Cloudant.prototype.automigrate %j', err);
@@ -951,6 +967,46 @@ Cloudant.prototype.automigrate = function(models, cb) {
   };
 };
 
+/**
+  * Check if the models exist
+  * @param {String[]} [models] A model name or an array of model names. If not
+  * present, apply to all models
+  * @param {Function} [cb] The callback function
+  */
+
+Cloudant.prototype.isActual = function(models, cb) {
+  var self = this;
+  var ok = true;
+
+  if ((!cb) && ('function' === typeof models)) {
+    cb = models;
+    models = undefined;
+  }
+  // First argument is a model name
+  if ('string' === typeof models) {
+    models = [models];
+  }
+
+  models = models || Object.keys(this._models);
+
+  async.eachSeries(models, function(model, finish) {
+    // when use `done` instead of `finish`, cloudant run into socket hang up
+    // error, rename it to solve the problem, but still worth investigate why
+    var mo = self.selectModel(model);
+    mo.db.index(function(err, result) {
+      if (err) return finish(err);
+      var indexName = 'lb-index-' + model;
+      var indexes = result.indexes || {};
+      var isFound = _.find(indexes, function(i) {
+        return i.name === indexName;
+      });
+      ok = ok && !!isFound;
+      finish();
+    });
+  }, function(err) {
+    cb(err, ok);
+  });
+};
 /*
  * Update the indexes.
  *

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -969,8 +969,7 @@ Cloudant.prototype.automigrate = function(models, cb) {
 
 /**
   * Check if the models exist
-  * @param {String[]} [models] A model name or an array of model names. If not
-  * present, apply to all models
+  * @param {String|String[]} [models] A model name or an array of model names. * If not present, apply to all models
   * @param {Function} [cb] The callback function
   */
 

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -901,14 +901,23 @@ Cloudant.prototype.selectModel = function(model, migrate) {
 
 /**
  * Perform autoupdate for the given models. It basically calls db.index()
- *
+ * It does NOT destroy previous model instances if model exists, only
+ * `automigrate` does that.
  * @param {String[]} [models] A model name or an array of model names. If not
  * present, apply to all models
  * @param {Function} [cb] The callback function
  */
 Cloudant.prototype.autoupdate = function(models, cb) {
   debug('Cloudant.prototype.autoupdate %j', models);
-  this.automigrate(models, cb);
+  var self = this;
+  async.eachSeries(models, function(model, cb2) {
+    debug('Cloudant.prototype.autoupdate model %j', model);
+    var mo = self.selectModel(model, true);
+    self.updateIndex(mo, model, cb2);
+  }, function(err) {
+    debug('Cloudant.prototype.autoupdate %j', err);
+    cb(err);
+  });
 };
 
 /**
@@ -916,25 +925,23 @@ Cloudant.prototype.autoupdate = function(models, cb) {
  * Notes: Cloudant stores a Model as a design doc in database,
  * `ddoc` is the doc's _id, auto-generated as 'lb-index-ddoc' + modelName,
  * `name` is the index name, auto-generated as 'lb-index' + modelName.
- * It does NOT store properties in the doc, which makes autoupdate actually
- * does the same thing as automigrate.
- * It does NOT destroy previous model instances if model exists, user needs
- * to manually destroy them if necessary.
- *
- * @param {String|String[]} [models] A model name or an array of model names. If not
- * present, apply to all models
+ * It does NOT store properties in the doc.
+ * `automigrate` one model destroys data if that model already exists.
+ * @param {String|String[]} [models] A model name or an array of model names.
+ * If not present, apply to all models
  * @param {Function} [cb] The callback function
  */
 Cloudant.prototype.automigrate = function(models, cb) {
   debug('Cloudant.prototype.automigrate models %j', models);
   var self = this;
-  async.eachSeries(models, function(model, cb2) {
-    debug('Cloudant.prototype.automigrate model %j', model);
-    var mo = self.selectModel(model, true);
-    self.updateIndex(mo, model, cb2);
-  }, function(err) {
-    debug('Cloudant.prototype.automigrate %j', err);
-    cb(err);
+  self.autoupdate(models, function(err) {
+    if (err) return cb(err);
+    async.eachSeries(models, function(model, cb2) {
+      self.destroyAll(model, {}, {}, cb2);
+    }, function(err) {
+      debug('Cloudant.prototype.automigrate %j', err);
+      cb(err);
+    });
   });
 };
 

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -946,11 +946,11 @@ Cloudant.prototype.automigrate = function(models, cb) {
       self.autoupdate(models, callback);
     }], cb);
   function checkExistingModels(checkCb) {
-    async.eachSeries(models, function(model, cb1) {
+    async.eachSeries(models, function(model, cb) {
       self.isActual(model, function(err, exist) {
-        if (err) return cb1(err);
+        if (err) return cb(err);
         if (exist) existingModels.push(model);
-        cb1();
+        cb();
       });
     }, function(err) {
       debug('Cloudant.prototype.automigrate checkExistingModels %j', err);
@@ -958,8 +958,8 @@ Cloudant.prototype.automigrate = function(models, cb) {
     });
   };
   function destroyData(destroyCb) {
-    async.eachSeries(existingModels, function(model, cb2) {
-      self.destroyAll(model, {}, {}, cb2);
+    async.eachSeries(existingModels, function(model, cb) {
+      self.destroyAll(model, {}, {}, cb);
     }, function(err) {
       debug('Cloudant.prototype.automigrate %j', err);
       destroyCb(err);

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -992,16 +992,21 @@ Cloudant.prototype.isActual = function(models, cb) {
     // when use `done` instead of `finish`, cloudant run into socket hang up
     // error, rename it to solve the problem, but still worth investigate why
     var mo = self.selectModel(model);
-    mo.db.index(function(err, result) {
-      if (err) return finish(err);
-      var indexName = 'lb-index-' + model;
-      var indexes = result.indexes || {};
-      var isFound = _.find(indexes, function(i) {
-        return i.name === indexName;
+    if (mo.db && (typeof mo.db.index === 'function')) {
+      mo.db.index(function(err, result) {
+        if (err) return finish(err);
+        var indexName = 'lb-index-' + model;
+        var indexes = result.indexes || {};
+        var isFound = _.find(indexes, function(i) {
+          return i.name === indexName;
+        });
+        ok = ok && !!isFound;
+        finish();
       });
-      ok = ok && !!isFound;
-      finish();
-    });
+    } else {
+      var errMsg = 'Fail to detect the database of model ' + model;
+      finish(new Error(errMsg));
+    }
   }, function(err) {
     cb(err, ok);
   });

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -934,15 +934,21 @@ Cloudant.prototype.autoupdate = function(models, cb) {
 Cloudant.prototype.automigrate = function(models, cb) {
   debug('Cloudant.prototype.automigrate models %j', models);
   var self = this;
-  self.autoupdate(models, function(err) {
-    if (err) return cb(err);
+  async.series([
+    function(callback) {
+      destroyData(callback);
+    },
+    function(callback) {
+      self.autoupdate(models, callback);
+    }], cb);
+  function destroyData(destroyCb) {
     async.eachSeries(models, function(model, cb2) {
       self.destroyAll(model, {}, {}, cb2);
     }, function(err) {
       debug('Cloudant.prototype.automigrate %j', err);
-      cb(err);
+      destroyCb(err);
     });
-  });
+  };
 };
 
 /*

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -36,14 +36,16 @@ describe('cloudant automigrate', function() {
     Foo = db.define('Foo', {
       updatedName: {type: String},
     });
-    db.autoupdate(function(err) {
-      if (err) return done(err);
-      Foo.find(function(err, results) {
+    db.once('connected', function() {
+      db.autoupdate(function(err) {
         if (err) return done(err);
-        // Verify autoupdate doesn't destroy existing data
-        results.length.should.equal(1);
-        results[0].name.should.equal('foo');
-        done();
+        Foo.find(function(err, results) {
+          if (err) return done(err);
+          // Verify autoupdate doesn't destroy existing data
+          results.length.should.equal(1);
+          results[0].name.should.equal('foo');
+          done();
+        });
       });
     });
   });
@@ -52,18 +54,22 @@ describe('cloudant automigrate', function() {
     Foo = db.define('Foo', {
       updatedName: {type: String},
     });
-    db.automigrate(function(err) {
-      if (err) return done(err);
-      Foo.find(function(err, result) {
+    db.once('connected', function() {
+      db.automigrate(function(err) {
         if (err) return done(err);
-        result.length.should.equal(0);
-        done();
+        Foo.find(function(err, result) {
+          if (err) return done(err);
+          result.length.should.equal(0);
+          done();
+        });
       });
     });
   });
   describe('isActual', function() {
     db = getSchema();
     it('returns true only when all models exist', function(done) {
+      // `isActual` requires the model be attached to a db,
+      // therefore use db.define here
       Foo = db.define('Foo', {
         name: {type: String},
       });
@@ -77,8 +83,8 @@ describe('cloudant automigrate', function() {
       });
     });
     it('returns false when one or more models not exist', function(done) {
-      // isActualTestFoo and isActualTestBar are not defined/used elsewhere
-      // so they don't exist in database
+      // model isActualTestFoo and isActualTestBar are not
+      // defined/used elsewhere, so they don't exist in database
       isActualTestFoo = db.define('isActualTestFoo', {
         name: {type: String},
       });

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -4,12 +4,10 @@
 // License text available at https://opensource.org/licenses/Artistic-2.0
 
 'use strict';
-var db, Foo, NotExist;
+var db, Foo, Bar, NotExist, isActualTestFoo, isActualTestBar;
+require('./init.js');
 
 describe('cloudant automigrate', function() {
-  before(function() {
-    require('./init.js');
-  });
   it('automigrates models attached to db', function(done) {
     db = getSchema();
     // Make sure automigrate doesn't destroy model doesn't exist
@@ -59,6 +57,45 @@ describe('cloudant automigrate', function() {
       Foo.find(function(err, result) {
         if (err) return done(err);
         result.length.should.equal(0);
+        done();
+      });
+    });
+  });
+  describe('isActual', function() {
+    db = getSchema();
+    it('returns true only when all models exist', function(done) {
+      Foo = db.define('Foo', {
+        name: {type: String},
+      });
+      Bar = db.define('Bar', {
+        name: {type: String},
+      });
+      db.isActual(['Foo', 'Bar'], function(err, ok) {
+        if (err) return done(err);
+        ok.should.equal(true);
+        done();
+      });
+    });
+    it('returns false when one or more models not exist', function(done) {
+      // isActualTestFoo and isActualTestBar are not defined/used elsewhere
+      // so they don't exist in database
+      isActualTestFoo = db.define('isActualTestFoo', {
+        name: {type: String},
+      });
+      isActualTestBar = db.define('isActualTestBar', {
+        name: {type: String},
+      });
+      db.isActual(['Foo', 'isActualTestFoo', 'isActualTestBar'],
+        function(err, ok) {
+          if (err) return done(err);
+          ok.should.equal(false);
+          done();
+        });
+    });
+    it('accepts string type single model as param', function(done) {
+      db.isActual('Foo', function(err, ok) {
+        if (err) return done(err);
+        ok.should.equal(true);
         done();
       });
     });

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -25,11 +25,24 @@ describe('cloudant automigrate', function() {
           if (err) return done(err);
           r.should.not.be.empty();
           r.name.should.equal('foo');
-          Foo.destroyAll(function(err) {
-            if (err) return done(err);
-            done();
-          });
+          done();
         });
+      });
+    });
+  });
+  it('autoupdates models attache to db', function(done) {
+    db = getSchema();
+    Foo = db.define('Foo', {
+      newName: {type: String},
+    });
+    db.autoupdate(function(err) {
+      if (err) return done(err);
+      Foo.find(function(err, results) {
+        if (err) return done(err);
+        // Verify autoupdate doesn't destroy existing data
+        results.length.should.equal(1);
+        results[0].name.should.equal('foo');
+        done();
       });
     });
   });

--- a/test/automigrate.test.js
+++ b/test/automigrate.test.js
@@ -17,6 +17,9 @@ describe('cloudant automigrate', function() {
     Foo = db.define('Foo', {
       name: {type: String},
     });
+    Bar = db.define('Bar', {
+      name: {type: String},
+    });
     db.once('connected', function() {
       db.automigrate(function verifyMigratedModel(err) {
         if (err) return done(err);

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -46,24 +46,9 @@ describe('cloudant connector', function() {
       },
     });
 
-<<<<<<< HEAD
     db.once('connected', function() {
-      db.automigrate(function cleanUpData(err) {
-      // automigrate only removes the design doc, but not instances' doc,
-      // so clean up data here just in case previous tests use same models.
-        if (err) return done(err);
-        Product.destroyAll(function removeModelInstances(err) {
-          if (err) return done(err);
-          CustomerSimple.destroyAll(function removeModelInstances(err) {
-            if (err) return done(err);
-            done();
-          });
-        });
-      });
+      db.automigrate(done);
     });
-=======
-    db.automigrate(done);
->>>>>>> 906054d... autoupdate and automigrate fix
   });
 
   describe('replaceOrCreate', function() {

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -46,6 +46,7 @@ describe('cloudant connector', function() {
       },
     });
 
+<<<<<<< HEAD
     db.once('connected', function() {
       db.automigrate(function cleanUpData(err) {
       // automigrate only removes the design doc, but not instances' doc,
@@ -60,6 +61,9 @@ describe('cloudant connector', function() {
         });
       });
     });
+=======
+    db.automigrate(done);
+>>>>>>> 906054d... autoupdate and automigrate fix
   });
 
   describe('replaceOrCreate', function() {

--- a/test/init.js
+++ b/test/init.js
@@ -14,9 +14,6 @@ var config = {
   username: process.env.CLOUDANT_USERNAME,
   password: process.env.CLOUDANT_PASSWORD,
   database: process.env.CLOUDANT_DATABASE,
-  plugin: 'retry',
-  retryAttempts: 10,
-  retryTimeout: 50,
 };
 
 console.log('env config ', config);

--- a/test/init.js
+++ b/test/init.js
@@ -14,6 +14,9 @@ var config = {
   username: process.env.CLOUDANT_USERNAME,
   password: process.env.CLOUDANT_PASSWORD,
   database: process.env.CLOUDANT_DATABASE,
+  plugin: 'retry',
+  retryAttempts: 10,
+  retryTimeout: 50,
 };
 
 console.log('env config ', config);

--- a/test/maxrows.test.js
+++ b/test/maxrows.test.js
@@ -13,7 +13,7 @@ describe('cloudant max rows', function() {
   // require more time to complete data cleanUp
   // There is no batchDestroy in cloudant, so `automigrate`
   // fetches all instances then delete them one by one
-  this.timeout(70000);
+  this.timeout(99999);
   var Foo;
   var N = 201;
   before(function(done) {

--- a/test/maxrows.test.js
+++ b/test/maxrows.test.js
@@ -13,7 +13,7 @@ describe('cloudant max rows', function() {
   // require more time to complete data cleanUp
   // There is no batchDestroy in cloudant, so `automigrate`
   // fetches all instances then delete them one by one
-  this.timeout(99999);
+  this.timeout(70000);
   var Foo;
   var N = 201;
   before(function(done) {

--- a/test/maxrows.test.js
+++ b/test/maxrows.test.js
@@ -27,22 +27,9 @@ describe('cloudant max rows', function() {
     });
     Thing.belongsTo('foo', {model: Foo});
     Foo.hasMany('things', {foreignKey: 'fooId'});
-<<<<<<< HEAD
     db.once('connected', function() {
-      db.automigrate(function cleanUpData(err) {
-        if (err) return done(err);
-        Thing.destroyAll(function removeModelInstances(err) {
-          if (err) return done(err);
-          Foo.destroyAll(function removeModelInstances(err) {
-            if (err) return done(err);
-            done();
-          });
-        });
-      });
+      db.automigrate(done);
     });
-=======
-    db.automigrate(done);
->>>>>>> 906054d... autoupdate and automigrate fix
   });
   it('create two hundred and one', function(done) {
     var foos = Array.apply(null, {length: N}).map(function(n, i) {

--- a/test/maxrows.test.js
+++ b/test/maxrows.test.js
@@ -11,7 +11,9 @@ var db, Thing;
 describe('cloudant max rows', function() {
   // This test suite creates large number of data,
   // require more time to complete data cleanUp
-  this.timeout(70000);
+  // There is no batchDestroy in cloudant, so `automigrate`
+  // fetches all instances then delete them one by one
+  this.timeout(99999);
   var Foo;
   var N = 201;
   before(function(done) {
@@ -25,6 +27,7 @@ describe('cloudant max rows', function() {
     });
     Thing.belongsTo('foo', {model: Foo});
     Foo.hasMany('things', {foreignKey: 'fooId'});
+<<<<<<< HEAD
     db.once('connected', function() {
       db.automigrate(function cleanUpData(err) {
         if (err) return done(err);
@@ -37,6 +40,9 @@ describe('cloudant max rows', function() {
         });
       });
     });
+=======
+    db.automigrate(done);
+>>>>>>> 906054d... autoupdate and automigrate fix
   });
   it('create two hundred and one', function(done) {
     var foos = Array.apply(null, {length: N}).map(function(n, i) {

--- a/test/regexp.test.js
+++ b/test/regexp.test.js
@@ -13,6 +13,7 @@ require('./init.js');
 var db;
 
 describe('cloudant regexp', function() {
+  this.timeout(99999);
   var Foo;
   var N = 10;
   before(function(done) {


### PR DESCRIPTION
### Description

Expected behaviour:
`autoupdate`: updateIndex for models attached to db.
~`automigrate`: do autoupdate, then destroy model instances if model existing.~
`automigrate`: destroy model instances if model existing, then do destroy.

Current behaviour:
`autoupdate` and `automigrate` does same thing: just updateIndex

#### Related issues
connect to strongloop/loopback-connector-cloudant#33


- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
