### PR TITLE
Fix updateOrCreate

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -744,13 +744,15 @@ Cloudant.prototype.updateOrCreate = function(model, data, cb) {
   var idName = self.idName(model);
   var id = data[idName];
   if (id) {
-    self.getCurrentRevision(model, id, function(err, rev) {
-      if (err) return cb(err);
-      if (rev) data._rev = rev;
-      self.create(model, data, {}, function(err) {
-        if (err) return cb(err);
-        cb(err, data, {isNewInstance: !rev});
-      });
+    self.updateAttributes(model, id, data, {}, function(err, docs) {
+      if (err && err.statusCode && err.statusCode === 404) {
+        self.create(model, data, {}, function(err) {
+          if (err) return cb(err);
+          return cb(err, data, {isNewInstance: true});
+        });
+      } else {
+        return cb(err, data, {isNewInstance: false});
+      }
     });
   } else {
     self.create(model, data, {}, function(err, id) {

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -710,7 +710,7 @@ Cloudant.prototype.updateAttributes = function(model, id, data, options, cb) {
     if (err) return cb(err);
     data = getPlainJSONData.call(self, model, data);
     _.mergeWith(doc, data, function(dest, src) { return src; });
-    self.create(model, data, options, function(err) {
+    self.create(model, doc, options, function(err) {
       if (err) return cb(err);
       return cb(err, data);
     });
@@ -755,9 +755,9 @@ Cloudant.prototype.updateOrCreate = function(model, data, cb) {
       }
     });
   } else {
-    self.create(model, data, {}, function(err, id) {
+    self.create(model, data, {}, function(err) {
       if (err) return cb(err);
-      cb(err, data, {isNewInstance: true});
+      return cb(err, data, {isNewInstance: true});
     });
   }
 };

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -117,6 +117,64 @@ describe('cloudant connector', function() {
       });
   });
 
+  describe('updateOrCreate', function() {
+    var data = [{
+      id: 10,
+      name: 'Foo',
+      age: 45,
+    }, {
+      id: 3,
+      name: 'Bar',
+      age: 25,
+    }, {
+      id: 120,
+      name: 'Baz',
+      age: 30,
+    }];
+
+    before(function(done) {
+      SimpleEmployee.create(data, done);
+    });
+
+    after(function(done) {
+      SimpleEmployee.destroyAll(null, {limit: QUERY_MAX}, done);
+    });
+
+    it('create new instance if instance does not exist', function(done) {
+      var newData = {
+        id: 35,
+        name: 'Cruz',
+        age: 22,
+      };
+      SimpleEmployee.updateOrCreate(newData,
+      function(err, result, newInstance) {
+        should.not.exist(err);
+        should.exist(result);
+        result.id.should.equal(newData.id);
+        result.name.should.equal(newData.name);
+        result.age.should.equal(newData.age);
+        done();
+      });
+    });
+
+    it('update existing instance if instance exists', function(done) {
+      var updatedData = {
+        id: 35,
+        name: 'Kim',
+        age: 18,
+      };
+      SimpleEmployee.updateOrCreate(updatedData,
+      function(err, result) {
+        should.not.exist(err);
+        should.exist(result);
+        result.id.should.equal(updatedData.id);
+        result.name.should.equal(updatedData.name);
+        result.age.should.equal(updatedData.age);
+        done();
+      });
+    });
+  });
+
   describe('replaceById', function() {
     after(function cleanUpData(done) {
       Product.destroyAll(null, {limit: QUERY_MAX}, done);

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -158,19 +158,31 @@ describe('cloudant connector', function() {
     });
 
     it('update existing instance if instance exists', function(done) {
-      var updatedData = {
+      var updatedData = [{
         id: 35,
         name: 'Kim',
         age: 18,
-      };
-      SimpleEmployee.updateOrCreate(updatedData,
+      }, {
+        id: 10,
+        name: 'Tim',
+        age: 60,
+      }];
+      SimpleEmployee.updateOrCreate(updatedData[0],
       function(err, result) {
         should.not.exist(err);
         should.exist(result);
-        result.id.should.equal(updatedData.id);
-        result.name.should.equal(updatedData.name);
-        result.age.should.equal(updatedData.age);
-        done();
+        result.id.should.equal(updatedData[0].id);
+        result.name.should.equal(updatedData[0].name);
+        result.age.should.equal(updatedData[0].age);
+        SimpleEmployee.updateOrCreate(updatedData[1],
+        function(err, result) {
+          should.not.exist(err);
+          should.exist(result);
+          result.id.should.equal(updatedData[1].id);
+          result.name.should.equal(updatedData[1].name);
+          result.age.should.equal(updatedData[1].age);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
### Description

Allow use of `updateAttributes` on the `updateOrCreate` prototype function. Try updating the data using the `updateAttributes` function first and if it fails, create the instance.

connect to https://github.com/strongloop-internal/scrum-apex/issues/204