### PR TITLE
Allow travis to run against the latest code base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 
 before_install:
   - sudo sh setup.sh
+  - npm config set registry http://ci.strongloop.com:4873/
 
 node_js:
   - 4


### PR DESCRIPTION
Allow travis to run against the latest code base instead of npmjs.