### PR TITLE
Fix updateAttributes method

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -134,10 +134,16 @@ Cloudant.prototype.toDB = function(modelName, modelObject, doc) {
  */
 Cloudant.prototype.fromDB = function(modelName, modelObject, doc) {
   var idName = this.idName(modelName);
+  // we should return the `id` as an int if the user specified the property as an int
+  if (idName)
+    var idType = modelObject.mo.properties.id.type.name;
   if (!doc) return doc;
   assert(doc._id);
   if (doc._id) {
-    doc[idName] = doc._id.toString();
+    if (idType === 'Number')
+      doc[idName] = parseInt(doc._id);
+    else
+      doc[idName] = doc._id;
     delete doc._id;
   }
   for (var i = 0; i < modelObject.dateFields.length; i++) {
@@ -463,7 +469,7 @@ Cloudant.prototype.updateAttributes = function(model, id, data, options, cb) {
     self.create(model, doc, options, function(err, id, rev) {
       if (err) return cb(err);
       doc._rev = rev;
-      return cb(err, doc);
+      return cb(err, self.fromDB(model, mo, doc));
     });
   });
 };
@@ -500,7 +506,7 @@ Cloudant.prototype.updateOrCreate = function(model, data, cb) {
         delete data._rev;
         self.create(model, data, {}, createHandler);
       } else {
-        return cb(err, self.fromDB(model, mo, docs), {isNewInstance: false});
+        return cb(err, docs, {isNewInstance: false});
       }
     });
   } else {

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -70,41 +70,6 @@ describe('cloudant connector', function() {
     });
   });
 
-  describe('updateAll and updateAttributes', function() {
-    var productInstance;
-    beforeEach('create Product', function(done) {
-      Product.create({
-        id: 1,
-        name: 'bread',
-        price: 100,
-      }, function(err, product) {
-        if (err) return done(err);
-        productInstance = product;
-        done();
-      });
-    });
-
-    afterEach(function(done) {
-      Product.destroyById(1, function(err) {
-        if (err) return done(err);
-        done();
-      });
-    });
-
-    it('accepts loopback model instance as input data for update',
-      function(done) {
-        productInstance.setAttribute('name', 'butter');
-        Product.updateAll({id: '1'}, productInstance, function(err, res) {
-          if (err) return done(err);
-
-          Product.findById('1', function(err, prod) {
-            prod.name.should.equal('butter');
-            done();
-          });
-        });
-      });
-  });
-
   describe('model with array props gets updated properly', function() {
     var prod1, prod2;
     before('create Product', function(done) {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -154,3 +154,50 @@ describe('updateAll', function() {
     });
   });
 });
+
+describe('updateAttributes', function() {
+  before(function(done) {
+    db = getDataSource();
+
+    Product = db.define('Product', {
+      name: {type: String},
+      description: {type: String},
+      price: {type: Number},
+    }, {forceId: false, updateOnLoad: true});
+
+    db.once('connected', function() {
+      db.automigrate(function(err) {
+        Product.create(bread, done);
+      });
+    });
+  });
+
+  after(cleanUpData);
+
+  it('update an attribute for a model instance', function(done) {
+    var updateFields = {
+      name: 'bread2',
+    };
+    Product.find(function(err, result) {
+      testUtil.hasError(err, result).should.not.be.ok();
+      testUtil.hasResult(err, result).should.be.ok();
+      var id = result[0].id;
+      var oldRev = result[0]._rev;
+      var newData = _.cloneDeep(result[0]);
+      newData.name = updateFields.name;
+      var product = new Product(result[0]);
+      product.updateAttributes(newData, function(err, result) {
+        testUtil.hasError(err, result).should.not.be.ok();
+        testUtil.hasResult(err, result).should.be.ok();
+        var newRev = result._rev;
+        oldRev.should.not.equal(newRev);
+        Product.find(function(err, result) {
+          testUtil.hasError(err, result).should.not.be.ok();
+          testUtil.hasResult(err, result).should.be.ok();
+          newRev.should.equal(result[0]._rev);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

~Currently in cloudant `update` performs a destructive update. With this change `update` function should do partial update.~

~- Use `updateAttributes` function to `update` a model instance.~
~- Use `update` function in `updateOrCreate` to update a model instance if exists.~

- Fix `updateAttributes` function to return the docs from `fromDB` function correctly. This is required since `updateOrCreate` calls `updateAttributes` now.
- Remove duplicate `updateAll` tests
- Allow `fromDB` function to return the id as a number if the original property was a number

connect to https://github.com/strongloop/loopback-connector-cloudant/issues/35
