### PR TITLE
Make updateAll return count of updated instances

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -534,9 +534,11 @@ Cloudant.prototype.updateAll = function(model, where, data, options, cb) {
       return cb();
     }, function(err) {
       if (err) return cb(err);
-      mo.db.bulk({docs: docs}, function(err, result) {
-        if (result) result.count = docs.length;
-        return cb(err, result);
+      mo.db.bulk({docs: docs}, function(err) {
+        if (err) return cb(err);
+        var res = {};
+        res.count = docs.length;
+        return cb(err, res);
       });
     });
   });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -140,16 +140,14 @@ describe('updateAll', function() {
       testUtil.hasError(err, result).should.not.be.ok();
       testUtil.hasResult(err, result).should.be.ok();
       var id = result[0].id;
-      var oldRev = result[0]._rev;
       Product.update({id: id}, newData, function(err, result) {
         testUtil.hasError(err, result).should.not.be.ok();
         testUtil.hasResult(err, result).should.be.ok();
-        var newRev = result[0].rev;
-        oldRev.should.not.equal(newRev);
+        result.should.have.property('count');
+        result.count.should.equal(1);
         Product.find(function(err, result) {
           testUtil.hasError(err, result).should.not.be.ok();
           testUtil.hasResult(err, result).should.be.ok();
-          newRev.should.equal(result[0]._rev);
           done();
         });
       });


### PR DESCRIPTION
Currently, cloudant returns an array of the updated instances instead of the count of the instances updated. This behaviour is not consistent with other connectors. The fix returns the number of instances updated instead of the instances itself.

connect to https://github.com/strongloop/loopback-connector-cloudant/issues/37