### PR TITLE
Do not strip rev value on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If you would like to have a `_rev` property on your model, as an end user, the o
   });
 ```
 
-**Note:** Cloudant does not allow customized `_rev` value, hence creating an instance with a `_rev` value will give an error. The onus is on the user if they fail to comply to this rule.
+**Note:** Cloudant does not allow customized `_rev` value, hence creating an instance with a `_rev` value will not give the expected result (i.e Cloudant's CREATE operation ignores the `_rev` value when provided and generates a random unique one). The onus is on the user if they fail to comply to this rule.
 
 Let's say we have an instance in the database:
 ```json

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -502,16 +502,12 @@ Cloudant.prototype.updateOrCreate = function(model, data, cb) {
     self.updateAttributes(model, id, data, {}, function(err, docs) {
       if (err && err.statusCode !== 404) return cb(err);
       else if (err && err.statusCode === 404) {
-        // strip out the `_rev` property before creation
-        delete data._rev;
         self.create(model, data, {}, createHandler);
       } else {
         return cb(err, docs, {isNewInstance: false});
       }
     });
   } else {
-    // strip out the `_rev` property before creation
-    delete data._rev;
     self.create(model, data, {}, createHandler);
   }
 };
@@ -634,8 +630,6 @@ Cloudant.prototype.replaceOrCreate = function(model, data, options, cb) {
         });
       });
     } else {
-      // strip out the `_rev` property before creation
-      delete data._rev;
       self.create(model, data, options, createHandler);
     }
   });

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -37,6 +37,27 @@ describe('create', function() {
       db.automigrate(done);
     });
   });
+
+  it('creates a model instance when `_rev` is provided', function(done) {
+    var newBread = _.cloneDeep(bread);
+    newBread._rev = '1-somerandomrev';
+    Product.create(newBread, function(err, result) {
+      err = testUtil.refinedError(err, result);
+      if (err) return done(err);
+      Product.findById(result.id, function(err, result) {
+        err = testUtil.refinedError(err, result);
+        if (err) return done(err);
+        // cloudant's post call ignores the `_rev` value for their own safety check
+        // therefore, creating an instance with a random `_rev` value works.
+        // however, it shall not be equal to the `_rev` value the user provides.
+        should.exist(result._rev);
+        should.notEqual(newBread._rev, result._rev);
+        testUtil.checkModel(newBread, result);
+        done();
+      });
+    });
+  });
+
   it('creates when model instance does not exist', function(done) {
     Product.create(bread, function(err, result) {
       err = testUtil.refinedError(err, result);


### PR DESCRIPTION
### Description
Currently, we as the ORM strips off the `_rev` value before doing a create operation. This is not needed since, cloudant ignores the `_rev` value when passed into the payload data for its own clarity. So if the user specifies the `_rev` value, **it is upto them to know that value won't be accepted as cloudant will automatically generate a unique _rev value**

connect to https://github.com/strongloop-internal/scrum-apex/issues/234