### PR TITLE
Updated cloudant dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "cloudant": "^1.4.0",
+    "cloudant": "^1.10.0-NOTICE",
     "debug": "^2.6.9",
     "lodash": "^4.17.4",
     "loopback-connector": "^4.0.0",


### PR DESCRIPTION
### Description
I simply updated the cloudant dependency because there is something wrong with this version of cloudant in the npm registry. 

I went ahead and added a PR for this because we are using this package in some of our apps that run on bluemix and our deployment pipelines are failing because this package will not build and I figured there may be other people having the same issue. :) 

Just FYI for any one stumbling across this, we have temporarily fixed this deployment issue by pointing our npm packages to this fork. But we are hoping to point it back to the main repo as soon as we can. 

#### Related issues
- connect to #185 
### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
