### PR TITLE
Global limit/all

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -244,7 +244,15 @@ Cloudant.prototype.all = function all(model, filter, options, cb) {
   };
   /* eslint-enable camelcase */
   if (filter.offset) query.skip = filter.offset;
-  if (filter.limit) query.limit = filter.limit;
+  if (filter.limit) {
+    query.limit = filter.limit;
+    debug('Cloudant.prototype.all filter contains limit as: ', query.limit);
+  } else {
+    query.limit = self.getLimit(filter.limit);
+    debug('Cloudant.prototype.all uses global limit as: ', query.limit);
+  };
+  if (query.limit == undefined) delete query.limit;
+
   query.sort = self.buildSort(mo, model, filter.order);
   debug('Cloudant.prototype.all %j %j %j', model, filter, query);
   include = function(docs, cb) {

--- a/test/id.test.js
+++ b/test/id.test.js
@@ -18,7 +18,11 @@ describe('using _id as id', function() {
       owner: {type: String},
       _id: {type: String, id: true},
     }, {forceId: true});
-    done();
+
+    // A workaround for 1.x version calling the async function `define`
+    // in a synchronous way. The fix for it resulted in a major version
+    // bump.
+    setTimeout(done, 3000);
   });
 
   after(function(done) {

--- a/test/settings.globalLimit.test.js
+++ b/test/settings.globalLimit.test.js
@@ -6,7 +6,6 @@
 'use strict';
 
 var _ = require('lodash');
-var should = require('should');
 var COUNT_OF_SAMPLES = 70;
 var db, TestCountUser;
 
@@ -22,7 +21,7 @@ function cleanUpData(done) {
   TestCountUser.destroyAll(done);
 }
 
-describe('count', function() {
+describe('global Limit', function() {
   before(function(done) {
     // globalLimit is greater than COUNT_OF_SAMPLES
     var config = _.assign(global.config, {globalLimit: 100});
@@ -40,7 +39,23 @@ describe('count', function() {
     TestCountUser.create(samples, done);
   });
 
-  it('returns more than 25 results with global limit set', function(done) {
+  it('find - returns more than 25 results', function(done) {
+    TestCountUser.find(function(err, r) {
+      if (err) return done(err);
+      r.length.should.equal(COUNT_OF_SAMPLES);
+      done();
+    });
+  });
+
+  it('find - limit in filter overrides the globalLimit', function(done) {
+    TestCountUser.find({limit: 1}, function(err, r) {
+      if (err) return done(err);
+      r.length.should.equal(1);
+      done();
+    });
+  });
+
+  it('count - returns more than 25 results', function(done) {
     TestCountUser.count(function(err, r) {
       if (err) return done(err);
       r.should.equal(COUNT_OF_SAMPLES);
@@ -48,7 +63,7 @@ describe('count', function() {
     });
   });
 
-  it('destroys more than 25 results with global limit set', function(done) {
+  it('destroyAll - destroys more than 25 results', function(done) {
     cleanUpData(function(err) {
       if (err) return done(err);
       TestCountUser.count(function(err, r) {


### PR DESCRIPTION
### Description

A workaround to fix https://github.com/strongloop/loopback/issues/4006
Details see https://github.com/strongloop/loopback/issues/4006#issuecomment-423558014

This fix at least allow people to retrieve all related model instances by setting a global limit.

*PS: Travis is unstable, but I don't have the time to investigate why, sorry. jenkins pass*



- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
