### PR TITLE
update node version to skip imported test for older version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ before_install:
   - npm config set registry http://ci.strongloop.com:4873/
 
 node_js:
-  - 6
   - 8
   - 10

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "description": "LoopBack Connector for IBM Cloudant DB",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "author": "IBM Corp.",
   "keywords": [


### PR DESCRIPTION
### Description
As we are changing to execute tests from both juggler versions 3.x and 4.x, and juggler v4 does not support Node.js 6, update node configs to skip tests for Node.js 6.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-cloudant/pull/206

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
