### PR TITLE
Update eslint version

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -5,19 +5,19 @@
 
 'use strict';
 
-var g = require('strong-globalize')();
-var DataSource = require('loopback-datasource-juggler').DataSource;
-var Cloudant = require('../'); // loopback-connector-cloudant
+const g = require('strong-globalize')();
+const DataSource = require('loopback-datasource-juggler').DataSource;
+const Cloudant = require('../'); // loopback-connector-cloudant
 
-var config = {
+const config = {
   username: process.env.CLOUDANT_USERNAME,
   password: process.env.CLOUDANT_PASSWORD,
   database: process.env.CLOUDANT_DATABASE,
 };
 
-var db = new DataSource(Cloudant, config);
+const db = new DataSource(Cloudant, config);
 
-var User = db.define('User', {
+const User = db.define('User', {
   name: {type: String},
   email: {type: String},
 });

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-var SG = require('strong-globalize');
+const SG = require('strong-globalize');
 SG.SetRootDir(__dirname);
 
 module.exports = require('./lib/cloudant');

--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -5,15 +5,15 @@
 
 'use strict';
 
-var g = require('strong-globalize')();
-var CouchDB = require('loopback-connector-couchdb2').CouchDB;
-var Driver = require('cloudant');
-var assert = require('assert');
-var debug = require('debug')('loopback:connector:cloudant');
-var async = require('async');
-var url = require('url');
-var util = require('util');
-var _ = require('lodash');
+const g = require('strong-globalize')();
+const CouchDB = require('loopback-connector-couchdb2').CouchDB;
+const Driver = require('cloudant');
+const assert = require('assert');
+const debug = require('debug')('loopback:connector:cloudant');
+const async = require('async');
+const url = require('url');
+const util = require('util');
+const _ = require('lodash');
 
 /**
  * Initialize the Cloudant connector for the given data source
@@ -74,11 +74,11 @@ Cloudant.prototype.getTypes = function() {
  */
 Cloudant.prototype.connect = function(cb) {
   debug('Cloudant.prototype.connect');
-  var self = this;
- // strip db name if defined in path of url before
+  const self = this;
+  // strip db name if defined in path of url before
   // sending it to our driver
   if (self.options.url) {
-    var parsedUrl = url.parse(self.options.url);
+    const parsedUrl = url.parse(self.options.url);
     if (parsedUrl.path && parsedUrl.path !== '/') {
       self.options.url = self.options.url.replace(parsedUrl.path, '');
       if (!self.options.database)
@@ -106,7 +106,7 @@ Cloudant.prototype.getDriverInst = function() {
   return this.cloudant;
 };
 
- /**
+/**
   * Called by function CouchDB.prototype.selectModel, overriden by Cloudant
   */
 Cloudant.prototype.getModelObjectSettings = function(mo) {
@@ -116,8 +116,8 @@ Cloudant.prototype.getModelObjectSettings = function(mo) {
 
 Cloudant.prototype.ping = function(cb) {
   debug('Cloudant.prototype.ping');
-  var self = this;
-  var driverInst = self.getDriverInst();
+  const self = this;
+  const driverInst = self.getDriverInst();
   if (driverInst) {
     driverInst.db.list(returnCB);
   } else {

--- a/lib/geo.js
+++ b/lib/geo.js
@@ -5,15 +5,15 @@
 
 'use strict';
 
-var URL = require('url');
-var assert = require('assert');
-var util = require('util');
-var _ = require('lodash');
+const URL = require('url');
+const assert = require('assert');
+const util = require('util');
+const _ = require('lodash');
 
 module.exports = mixinGeo;
 
 function mixinGeo(Cloudant) {
-  var debug = require('debug')('loopback:connector:cloudant:geo');
+  const debug = require('debug')('loopback:connector:cloudant:geo');
 
   /**
    * Gets data at `/{db}/_design/{ddocName}/_geo/{indexName}?{options}`
@@ -40,10 +40,10 @@ function mixinGeo(Cloudant) {
     debug('Cloudant.prototype.geoDocs ddocName %s indexName %s options %s',
       ddocName, indexName, options);
 
-    var self = this;
-    var db = this.cloudant.use(self.getDbName(self));
+    const self = this;
+    const db = this.cloudant.use(self.getDbName(self));
 
     db.geo(ddocName, indexName, options, cb);
   };
-};
+}
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -5,15 +5,15 @@
 
 'use strict';
 
-var URL = require('url');
-var assert = require('assert');
-var util = require('util');
-var _ = require('lodash');
+const URL = require('url');
+const assert = require('assert');
+const util = require('util');
+const _ = require('lodash');
 
 module.exports = mixinView;
 
 function mixinView(Cloudant) {
-  var debug = require('debug')('loopback:connector:cloudant:view');
+  const debug = require('debug')('loopback:connector:cloudant:view');
 
   /**
    * Gets data at `/{db}/_design/{ddocName}/views/{viewName}`
@@ -40,8 +40,8 @@ function mixinView(Cloudant) {
     debug('Cloudant.prototype.view ddocName %s viewName %s options %s',
       ddocName, viewName, options);
 
-    var self = this;
-    var db = this.cloudant.use(self.getDbName(self));
+    const self = this;
+    const db = this.cloudant.use(self.getDbName(self));
 
     db.view(ddocName, viewName, options, cb);
   };
@@ -52,11 +52,11 @@ function mixinView(Cloudant) {
    * @return {String} The database name
    */
   Cloudant.prototype.getDbName = function(connector) {
-    var dbName = connector.settings.database || connector.settings.db ||
+    const dbName = connector.settings.database || connector.settings.db ||
     getDbFromUrl(connector.settings.url);
     return dbName;
   };
-};
+}
 
 /**
  * Parse url and return the database name if provided
@@ -64,7 +64,7 @@ function mixinView(Cloudant) {
  * @return {String} The database name parsed from url
  */
 function getDbFromUrl(url) {
-  var parsedUrl = URL.parse(url);
+  const parsedUrl = URL.parse(url);
   if (parsedUrl.path && parsedUrl.path !== '/')
     return parsedUrl.path.split('/')[1];
   return '';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
     "test": "node test.js",
     "posttest": "npm run lint",
     "mocha": "./node_modules/.bin/_mocha --timeout 40000 --require strong-mocha-interfaces --require test/init.js --ui strong-bdd"
@@ -33,8 +34,8 @@
   },
   "devDependencies": {
     "dockerode": "^2.4.3",
-    "eslint": "^2.13.1",
-    "eslint-config-loopback": "^4.0.0",
+    "eslint": "^5.16.0",
+    "eslint-config-loopback": "^13.1.0",
     "loopback-datasource-juggler": "^3.0.0",
     "mocha": "^5.2.0",
     "ms": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -5,16 +5,16 @@
 
 'use strict';
 
-var _ = require('lodash');
-var async = require('async');
-var spawn = require('child_process').spawn;
-var docker = new require('dockerode')();
-var fmt = require('util').format;
-var http = require('http');
-var ms = require('ms');
+const _ = require('lodash');
+const async = require('async');
+const spawn = require('child_process').spawn;
+const docker = new require('dockerode')();
+const fmt = require('util').format;
+const http = require('http');
+const ms = require('ms');
 
 // we don't pass any node flags, so we can call _mocha instead the wrapper
-var mochaBin = require.resolve('mocha/bin/_mocha');
+const mochaBin = require.resolve('mocha/bin/_mocha');
 
 process.env.CLOUDANT_DATABASE = 'test-db';
 process.env.CLOUDANT_PASSWORD = 'pass';
@@ -26,10 +26,10 @@ process.env.CLOUDANT_PORT = 'TBD';
 process.env.CLOUDANT_HOST = 'TBD';
 process.env.CLOUDANT_URL = 'TBD';
 
-var CONNECT_RETRIES = 30;
-var CONNECT_DELAY = ms('5s');
+const CONNECT_RETRIES = 30;
+const CONNECT_DELAY = ms('5s');
 
-var containerToDelete = null;
+let containerToDelete = null;
 
 async.waterfall([
   dockerStart('ibmcom/cloudant-developer:2.0.1'),
@@ -53,9 +53,9 @@ async.waterfall([
 
 function sleep(n) {
   return function delayedPassThrough() {
-    var args = [].slice.call(arguments);
+    const args = [].slice.call(arguments);
     // last argument is the callback
-    var next = args.pop();
+    const next = args.pop();
     // prepend `null` to indicate no error
     args.unshift(null);
     setTimeout(function() {
@@ -98,14 +98,14 @@ function setCloudantEnv(container, next) {
     // if swarm, Node.Ip will be set to actual node's IP
     // if not swarm, but remote docker, use docker host's IP
     // if local docker, use localhost
-    var host = _.get(c, 'Node.IP', _.get(docker, 'modem.host', '127.0.0.1'));
+    const host = _.get(c, 'Node.IP', _.get(docker, 'modem.host', '127.0.0.1'));
     // container's port 80 is dynamically mapped to an external port
-    var port = _.get(c,
+    const port = _.get(c,
       ['NetworkSettings', 'Ports', '80/tcp', '0', 'HostPort']);
     process.env.CLOUDANT_PORT = port;
     process.env.CLOUDANT_HOST = host;
-    var usr = process.env.CLOUDANT_USERNAME;
-    var pass = process.env.CLOUDANT_PASSWORD;
+    const usr = process.env.CLOUDANT_USERNAME;
+    const pass = process.env.CLOUDANT_PASSWORD;
     process.env.CLOUDANT_URL = 'http://' + usr + ':' + pass + '@' +
       host + ':' + port;
     console.log('env:', _.pick(process.env, [
@@ -122,7 +122,7 @@ function setCloudantEnv(container, next) {
 
 function waitFor(path) {
   return function waitForPath(container, next) {
-    var opts = {
+    const opts = {
       host: process.env.CLOUDANT_HOST,
       port: process.env.CLOUDANT_PORT,
       auth: process.env.CLOUDANT_USERNAME + ':' + process.env.CLOUDANT_PASSWORD,
@@ -157,7 +157,7 @@ function waitFor(path) {
 
 function createDB(db) {
   return function create(container, next) {
-    var opts = {
+    const opts = {
       method: 'PUT',
       path: '/' + db,
       host: process.env.CLOUDANT_HOST,
@@ -172,8 +172,8 @@ function createDB(db) {
         setImmediate(next, null, container);
       });
     })
-    .on('error', next)
-    .end();
+      .on('error', next)
+      .end();
   };
 }
 

--- a/test/cloudant.connection.test.js
+++ b/test/cloudant.connection.test.js
@@ -5,15 +5,15 @@
 
 'use strict';
 require('./init.js');
-var should = require('should');
+const should = require('should');
 
 describe('cloudant connection', function() {
   context('with an invalid cloudant connection', function() {
     it('returns error with fake url', function(done) {
-      var fakeConfig = {
+      const fakeConfig = {
         url: 'http://fake:foo@localhost:4',
       };
-      var fakeDB = global.getDataSource(fakeConfig);
+      const fakeDB = global.getDataSource(fakeConfig);
       fakeDB.once('error', function(err) {
         should.exist(err);
         err.message.should.match(/error happened in your connection/);

--- a/test/cloudant.test.js
+++ b/test/cloudant.test.js
@@ -6,16 +6,16 @@
 'use strict';
 
 require('./init.js');
-var Cloudant = require('../lib/cloudant');
-var _ = require('lodash');
-var should = require('should');
-var testUtil = require('./lib/test-util');
-var url = require('url');
-var db, Product, CustomerSimple, SimpleEmployee;
+const Cloudant = require('../lib/cloudant');
+const _ = require('lodash');
+const should = require('should');
+const testUtil = require('./lib/test-util');
+const url = require('url');
+let db, Product, CustomerSimple, SimpleEmployee;
 
 describe('cloudant connector', function() {
   before(function(done) {
-    db = getDataSource();
+    db = global.getDataSource();
 
     Product = db.define('Product', {
       name: {type: String},
@@ -82,7 +82,7 @@ describe('cloudant connector', function() {
   });
 
   describe('model with array props gets updated properly', function() {
-    var prod1, prod2;
+    let prod1, prod2;
     before('create Product', function(done) {
       Product.create({
         id: 1,
@@ -143,42 +143,42 @@ describe('cloudant connector', function() {
       });
 
     it('updates all matching instances with array props',
-   function(done) {
-     var data = {
-       price: 200,
-       releases: [7],
-       type: ['everything'],
-       foo: [{id: 1, name: 'bar'}],
-     };
+      function(done) {
+        const data = {
+          price: 200,
+          releases: [7],
+          type: ['everything'],
+          foo: [{id: 1, name: 'bar'}],
+        };
 
-     Product.updateAll({price: 100}, data, function(err, res) {
-       if (err) done(err);
-       Product.find(function(err, res) {
-         if (err) done(err);
-         res.length.should.equal(2);
-         res[0].name.should.oneOf(prod1.name, prod2.name);
-         res[0].price.should.equal(data.price);
-         res[0].releases.should.deepEqual(data.releases);
-         res[0].type.should.deepEqual(data.type);
-         res[0].foo.should.deepEqual(data.foo);
-         res[1].name.should.oneOf(prod1.name, prod2.name);
-         res[1].price.should.equal(data.price);
-         res[1].releases.should.deepEqual(data.releases);
-         res[1].type.should.deepEqual(data.type);
-         res[1].foo.should.deepEqual(data.foo);
-         done();
-       });
-     });
-   });
+        Product.updateAll({price: 100}, data, function(err, res) {
+          if (err) done(err);
+          Product.find(function(err, res) {
+            if (err) done(err);
+            res.length.should.equal(2);
+            res[0].name.should.oneOf(prod1.name, prod2.name);
+            res[0].price.should.equal(data.price);
+            res[0].releases.should.deepEqual(data.releases);
+            res[0].type.should.deepEqual(data.type);
+            res[0].foo.should.deepEqual(data.foo);
+            res[1].name.should.oneOf(prod1.name, prod2.name);
+            res[1].price.should.equal(data.price);
+            res[1].releases.should.deepEqual(data.releases);
+            res[1].type.should.deepEqual(data.type);
+            res[1].foo.should.deepEqual(data.foo);
+            done();
+          });
+        });
+      });
   });
 
   // the test suite is to make sure when
   // user queries against a non existing property
   // the app won't crash
   describe('nested property', function() {
-    var seedCount = 0;
+    let seedCount = 0;
     before(function createSampleData(done) {
-      var seedItems = seed();
+      const seedItems = seed();
       seedCount = seedItems.length;
       CustomerSimple.create(seedItems, done);
     });
@@ -200,11 +200,11 @@ describe('cloudant connector', function() {
         });
       it('returns null when first level property is array', function(done) {
         CustomerSimple.find({where: {'friends.name': {regexp: /^Ringo/}}},
-        function(err, customers) {
-          if (err) return done(err);
-          customers.should.be.empty();
-          done();
-        });
+          function(err, customers) {
+            if (err) return done(err);
+            customers.should.be.empty();
+            done();
+          });
       });
       it('returns result when first level property is array type' +
       ' and $elemMatch provided', function(done) {
@@ -213,9 +213,9 @@ describe('cloudant connector', function() {
         function(err, customers) {
           if (err) return done(err);
           customers.length.should.be.equal(2);
-          var expected1 = ['John Lennon', 'Paul McCartney'];
-          var expected2 = ['Paul McCartney', 'John Lennon'];
-          var actual = customers.map(function(c) { return c.name; });
+          const expected1 = ['John Lennon', 'Paul McCartney'];
+          const expected2 = ['Paul McCartney', 'John Lennon'];
+          const actual = customers.map(function(c) { return c.name; });
           should(actual).be.oneOf(expected1, expected2);
           done();
         });
@@ -223,11 +223,11 @@ describe('cloudant connector', function() {
       it('returns null when multi-level nested property' +
       ' contains array type', function(done) {
         CustomerSimple.find({where: {'address.tags.tag': 'business'}},
-        function(err, customers) {
-          if (err) return done(err);
-          customers.should.be.empty();
-          done();
-        });
+          function(err, customers) {
+            if (err) return done(err);
+            customers.should.be.empty();
+            done();
+          });
       });
       it('returns result when multi-level nested property contains array type' +
       ' and $elemMatch provided', function(done) {
@@ -243,12 +243,12 @@ describe('cloudant connector', function() {
       });
       it('returns error missing data type when sorting', function(done) {
         CustomerSimple.find({where: {'address.state': 'CA'},
-        order: 'address.state DESC'},
-          function(err, customers) {
-            should.exist(err);
-            err.message.should.match(/no_usable_index,missing_sort_index/);
-            done();
-          });
+          order: 'address.state DESC'},
+        function(err, customers) {
+          should.exist(err);
+          err.message.should.match(/no_usable_index,missing_sort_index/);
+          done();
+        });
       });
       it('returns result when sorting type provided - missing first level ' +
         'property', function(done) {
@@ -258,9 +258,9 @@ describe('cloudant connector', function() {
           order: 'missingProperty'}, function(err, customers) {
           if (err) return done(err);
           customers.length.should.be.equal(2);
-          var expected1 = ['San Mateo', 'San Jose'];
-          var expected2 = ['San Jose', 'San Mateo'];
-          var actual = customers.map(function(c) { return c.address.city; });
+          const expected1 = ['San Mateo', 'San Jose'];
+          const expected2 = ['San Jose', 'San Mateo'];
+          const actual = customers.map(function(c) { return c.address.city; });
           should(actual).be.oneOf(expected1, expected2);
           done();
         });
@@ -271,17 +271,17 @@ describe('cloudant connector', function() {
       // - Each object in the sort array has a single key.
       // http://docs.couchdb.org/en/2.0.0/api/database/find.html#sort-syntax
       it('returns result when sorting type provided - nested property',
-      function(done) {
-        CustomerSimple.find({where: {'address.city': {gt: null}},
-          order: 'address.city DESC'},
-        function(err, customers) {
-          if (err) return done(err);
-          customers.length.should.be.equal(2);
-          customers[0].address.city.should.be.eql('San Mateo');
-          customers[1].address.city.should.be.eql('San Jose');
-          done();
+        function(done) {
+          CustomerSimple.find({where: {'address.city': {gt: null}},
+            order: 'address.city DESC'},
+          function(err, customers) {
+            if (err) return done(err);
+            customers.length.should.be.equal(2);
+            customers[0].address.city.should.be.eql('San Mateo');
+            customers[1].address.city.should.be.eql('San Jose');
+            done();
+          });
         });
-      });
     });
     describe('defined in modelDef', function() {
       it('returns result when complete query of' +
@@ -300,7 +300,7 @@ describe('cloudant connector', function() {
   });
 
   describe('allow numerical `id` value', function() {
-    var data = [{
+    const data = [{
       id: 1,
       name: 'John Chow',
       age: 45,
@@ -313,7 +313,7 @@ describe('cloudant connector', function() {
       name: 'Michael Santer',
       age: 30,
     }];
-    var rev;
+    let rev;
 
     before(function(done) {
       SimpleEmployee.create(data, function(err, result) {
@@ -369,7 +369,7 @@ describe('cloudant connector', function() {
     });
 
     it('replace instances with numerical id (replaceById)', function(done) {
-      var updatedData = {
+      const updatedData = {
         id: data[1].id,
         name: 'Christian Thompson',
         age: 32,
@@ -392,7 +392,7 @@ describe('cloudant connector', function() {
             should.equal(result.length, 3);
             // checkData ignoring its order
             data.forEach(function(item, index) {
-              var r = _.find(result, function(o) {
+              const r = _.find(result, function(o) {
                 return o.toObject().id === item.id;
               });
               testUtil.checkData(data[index], r.toObject());
@@ -449,9 +449,9 @@ describe('cloudant connector', function() {
 describe('cloudant constructor', function() {
   it('should allow passthrough of properties in the settings object',
     function() {
-      var ds = getDataSource();
+      const ds = global.getDataSource();
       ds.settings = _.clone(ds.settings) || {};
-      var result = {};
+      let result = {};
       ds.settings.Driver = function(options) {
         result = options;
       };
@@ -460,7 +460,7 @@ describe('cloudant constructor', function() {
       };
       ds.settings.plugin = 'whack-a-mole';
       ds.settings.requestDefault = {proxy: 'http://localhost:8080'};
-      var connector = Cloudant.initialize(ds, function(err) {
+      const connector = Cloudant.initialize(ds, function(err) {
         should.not.exist(err);
         should.exist(result.foobar);
         result.foobar.foo.should.be.equal('bar');
@@ -471,39 +471,39 @@ describe('cloudant constructor', function() {
     });
 
   it('should pass the url as an object property', function() {
-    var ds = getDataSource();
+    const ds = global.getDataSource();
     ds.settings = _.clone(ds.settings) || {};
-    var result = {};
+    let result = {};
     ds.settings.Driver = function(options) {
       result = options;
     };
     ds.settings.url = 'https://totallyfakeuser:fakepass@definitelynotreal.cloudant.com';
-    var connector = Cloudant.initialize(ds, function() {
+    const connector = Cloudant.initialize(ds, function() {
       // The url will definitely cause a connection error, so ignore.
       should.exist(result.url);
       result.url.should.equal(ds.settings.url);
     });
   });
   it('should convert first part of url path to database name', function(done) {
-    var myConfig = _.clone(global.config);
+    const myConfig = _.clone(global.config);
     myConfig.url = myConfig.url + '/some/random/path';
     myConfig.database = '';
-    var result = {};
+    let result = {};
     myConfig.Driver = function(options) {
       result = options;
     };
-    var ds = getDataSource(myConfig);
+    const ds = global.getDataSource(myConfig);
     result.url.should.equal(global.config.url);
     result.database.should.equal('some');
     done();
   });
 
   it('should give 401 error for wrong creds', function(done) {
-    var myConfig = _.clone(global.config);
-    var parsedUrl = url.parse(myConfig.url);
+    const myConfig = _.clone(global.config);
+    const parsedUrl = url.parse(myConfig.url);
     parsedUrl.auth = 'foo:bar';
     myConfig.url = parsedUrl.format();
-    var ds = getDataSource(myConfig);
+    const ds = global.getDataSource(myConfig);
     ds.once('error', function(err) {
       should.exist(err);
       err.statusCode.should.equal(401);
@@ -513,12 +513,12 @@ describe('cloudant constructor', function() {
     });
   });
   it('should give 404 error for nonexistant db', function(done) {
-    var myConfig = _.clone(global.config);
-    var parsedUrl = url.parse(myConfig.url);
+    const myConfig = _.clone(global.config);
+    const parsedUrl = url.parse(myConfig.url);
     parsedUrl.path = '';
     myConfig.url = parsedUrl.format();
     myConfig.database = 'idontexist';
-    var ds = getDataSource(myConfig);
+    const ds = global.getDataSource(myConfig);
     ds.once('error', function(err) {
       should.exist(err);
       err.statusCode.should.equal(404);
@@ -530,7 +530,7 @@ describe('cloudant constructor', function() {
 });
 
 function seed() {
-  var beatles = [
+  const beatles = [
     {
       seq: 0,
       name: 'John Lennon',

--- a/test/geo.test.js
+++ b/test/geo.test.js
@@ -6,19 +6,19 @@
 'use strict';
 
 require('./init.js');
-var _ = require('lodash');
-var async = require('async');
-var should = require('should');
-var url = require('url');
+const _ = require('lodash');
+const async = require('async');
+const should = require('should');
+const url = require('url');
 
-var db, sampleData;
+let db, sampleData;
 
 describe('cloudant geo', function() {
   describe('viewDocs', function(done) {
     before(function(done) {
       db = global.getDataSource();
-      var connector = db.connector;
-      var driverInstance;
+      const connector = db.connector;
+      let driverInstance;
 
       db.once('connected', function(err) {
         driverInstance = connector[connector.name]
@@ -29,14 +29,14 @@ describe('cloudant geo', function() {
       function insertSampleData(cb) {
         sampleData = generateSamples();
         driverInstance.bulk({docs: sampleData}, cb);
-      };
+      }
 
       function insertViewDdoc(cb) {
-        var viewFunction = 'function(doc) { if ' +
+        const viewFunction = 'function(doc) { if ' +
           '(doc.geometry && doc.geometry.coordinates) { ' +
           'st_index(doc.geometry); } };';
 
-        var ddoc = {
+        const ddoc = {
           _id: '_design/geo',
           'st_indexes': {
             getGeo: {
@@ -46,7 +46,7 @@ describe('cloudant geo', function() {
         };
 
         driverInstance.insert(JSON.parse(JSON.stringify(ddoc)), cb);
-      };
+      }
     });
 
     it('returns result by quering a view', function(done) {
@@ -64,12 +64,12 @@ describe('cloudant geo', function() {
         radius: 250000,
         'include_docs': true,
       }, function(err, results) {
-        var expectedLocationIds = [1, 2, 3, 4];
+        const expectedLocationIds = [1, 2, 3, 4];
         results.rows.forEach(belongsToModelLocation);
         done(err);
 
         function belongsToModelLocation(elem) {
-          var doc = elem.doc;
+          const doc = elem.doc;
           doc.geoModel.should.equal('geo');
           _.indexOf(expectedLocationIds, doc.locationId).should.not.equal(-1);
         }
@@ -79,7 +79,7 @@ describe('cloudant geo', function() {
 });
 
 function generateSamples() {
-  var samples = [
+  const samples = [
     {
       geoModel: 'geo',
       locationId: 1,

--- a/test/imported.test.js
+++ b/test/imported.test.js
@@ -7,11 +7,11 @@
 
 describe('cloudant imported features', function() {
   before(function() {
-    IMPORTED_TEST = true;
+    global.IMPORTED_TEST = true;
   });
 
   after(function() {
-    IMPORTED_TEST = false;
+    global.IMPORTED_TEST = false;
   });
 
   require('loopback-datasource-juggler/test/include.test.js');

--- a/test/init.js
+++ b/test/init.js
@@ -7,10 +7,10 @@
 
 module.exports = require('should');
 
-var DataSource = require('loopback-datasource-juggler').DataSource;
-var _ = require('lodash');
+const DataSource = require('loopback-datasource-juggler').DataSource;
+const _ = require('lodash');
 
-var config = {
+const config = {
   url: process.env.CLOUDANT_URL,
   username: process.env.CLOUDANT_USERNAME,
   password: process.env.CLOUDANT_PASSWORD,
@@ -25,7 +25,7 @@ console.log('env config ', config);
 global.config = config;
 global.IMPORTED_TEST = false;
 
-var skips = [
+const skips = [
   'find all limt ten',
   'find all skip ten limit ten',
   'find all skip two hundred',
@@ -41,13 +41,13 @@ if (process.env.LOOPBACK_MOCHA_SKIPS) {
 }
 
 global.getDataSource = global.getSchema = function(customConfig) {
-  var db = new DataSource(require('../'), customConfig || config);
+  const db = new DataSource(require('../'), customConfig || config);
   db.log = function(a) {
     console.log(a);
   };
 
-  var originalConnector = _.clone(db.connector);
-  var overrideConnector = {};
+  const originalConnector = _.clone(db.connector);
+  const overrideConnector = {};
 
   db.once('connected', function() {
     originalConnector.cloudant = db.connector.cloudant;
@@ -59,7 +59,7 @@ global.getDataSource = global.getSchema = function(customConfig) {
       db.once('connected', function() {
         originalConnector.automigrate(models, cb);
       });
-    };
+    }
   };
 
   overrideConnector.autoupdate = function(models, cb) {
@@ -68,23 +68,23 @@ global.getDataSource = global.getSchema = function(customConfig) {
       db.once('connected', function() {
         originalConnector.autoupdate(models, cb);
       });
-    };
+    }
   };
 
   overrideConnector.save = function(model, data, options, cb) {
-    if (!IMPORTED_TEST) {
+    if (!global.IMPORTED_TEST) {
       return originalConnector.save(model, data, options, cb);
     } else {
-      var self = this;
-      var idName = self.idName(model);
-      var id = data[idName];
-      var mo = self.selectModel(model);
+      const self = this;
+      const idName = self.idName(model);
+      const id = data[idName];
+      const mo = self.selectModel(model);
       data[idName] = id.toString();
 
       mo.db.get(id, function(err, doc) {
         if (err) return cb(err);
         data._rev = doc._rev;
-        var saveHandler = function(err, id) {
+        const saveHandler = function(err, id) {
           if (err) return cb(err);
           mo.db.get(id, function(err, doc) {
             if (err) return cb(err);
@@ -97,7 +97,7 @@ global.getDataSource = global.getSchema = function(customConfig) {
   };
 
   overrideConnector._insert = function(model, data, cb) {
-    if (!IMPORTED_TEST) {
+    if (!global.IMPORTED_TEST) {
       return originalConnector._insert(model, data, cb);
     } else {
       originalConnector._insert(model, data, function(err, rid, rrev) {

--- a/test/lib/test-util.js
+++ b/test/lib/test-util.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-var should = require('should');
+const should = require('should');
 
 /**
  * Helper method to validate top-level properties on a model.
@@ -22,7 +22,7 @@ exports.checkModel = function checkModel(expected, actual) {
  * @param {object} actual The actual object.
  */
 exports.checkData = function checkData(expected, actual) {
-  for (var i in expected) {
+  for (const i in expected) {
     should.exist(actual[i]);
     actual[i].should.eql(expected[i]);
   }
@@ -40,7 +40,7 @@ exports.QUERY_MAX = 1000;
  * @returns {Error} The refined Error message.
  */
 exports.refinedError = function refinedError(err, result) {
-  var newErr = null;
+  let newErr = null;
   if (!!err && result)
     newErr = new Error('both err and result were returned!');
   else if (err) newErr = err;


### PR DESCRIPTION
### Description
As we are changing to execute tests from both juggler versions 3.x and 4.x, update `eslint` to newer version to pass CI tests.
The version of `eslint` matches with ~[mongoDB connector](https://github.com/strongloop/loopback-connector-mongodb/commit/830f83a9eb59190975436b9d7bf353fe743b219b#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R40)~ latest version

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-connector-cloudant/pull/206

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
