### PR TITLE
feat: partitioned index

### DIFF
--- a/lib/cloudant.js
+++ b/lib/cloudant.js
@@ -136,3 +136,4 @@ Cloudant.prototype.ping = function(cb) {
 // mixins
 require('./view')(Cloudant);
 require('./geo')(Cloudant);
+require('./migrate')(Cloudant);

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,0 +1,207 @@
+// Copyright IBM Corp. 2019. All Rights Reserved.
+// Node module: loopback-connector-cloudant
+// This file is licensed under the Apache License 2.0.
+// License text available at https://opensource.org/licenses/Apache-2.0
+
+'use strict';
+
+const _ = require('lodash');
+const inspect = require('util').inspect;
+const debug = require('debug')('loopback:connector:cloudant');
+
+module.exports = mixinMigrate;
+
+function mixinMigrate(Cloudant) {
+  /**
+    * Used in function `migrateOrUpdateIndex`.
+    * Create index with index object.
+    * @param {Object} mo  The model configuration
+    * @param {String} model  The model name.
+    * @param {String} name  The index name.
+    * @param {Object} indexObj The index object
+    * e.g. {fields: [{"foo": "asc"}, {"bar": "asc"}], partitioned: true}
+    * @param {Function} cb
+  */
+  Cloudant.prototype._createIndex = function(mo, model, name, indexObj, cb) {
+    const self = this;
+    debug('createIndex fields before coercion: %s', inspect(indexObj.fields));
+    let fields = self.coerceIndexFields(indexObj.fields);
+    debug('createIndex fields after coercion: %s', inspect(fields));
+    fields = self.addModelViewToIndex(mo.modelView, fields);
+    debug('createIndex fields after add model index: %s', inspect(fields));
+    // naming convertion: '_design/LBModel__Foo__LBIndex__foo_index',
+    // here the driver api takes in the name without prefix '_design/'
+    const config = {
+      ddocName: self.getIndexModelPrefix(mo) + '__' + model + '__' +
+      self.getIndexPropertyPrefix(mo) + '__' + name,
+      indexName: name,
+      fields: fields,
+      partitioned: indexObj.partitioned,
+    };
+    self.createIndexWithConfig(config, cb);
+  };
+
+  /**
+   * Used in function `getModifyIndexes()`.
+   * Generate indexes for model properties that are configured as
+   * `{index: true}`, return model property indexes as objects,
+   * e.g. {fields: [{name: 'asc'}], partitioned: true}.
+   *
+   * @param {Object} indexes indexes from model config, retrieved in
+   * `getModifyIndexes()`
+   */
+  Cloudant.prototype._generatePropertyLevelIndexes = function(indexes) {
+    const results = {};
+    for (const key in indexes) {
+      const field = {};
+      // By default the order will be `asc`, partitioned is false,
+      // please create Model level index if you need `desc` or partitioned index
+      field[key.split('_index')[0]] = 'asc';
+      const fields = [field];
+      results[key] = {fields: fields, partitioned: false};
+    }
+    return results;
+  };
+
+  /**
+   * Used in function `getModifyIndexes()`.
+   * Generate indexes for indexes defined in the model config.
+   * Return indexes as objects, e.g.
+   * {fields: [{foo: 'asc'}, {bar: 'desc'}], partitioned: true}
+   *
+   * @param {Object} indexes indexes from model config, provided by
+   * `getModifyIndexes()`
+   */
+  Cloudant.prototype._generateModelLevelIndexes = function(indexes, cb) {
+    const results = {};
+    for (const key in indexes) {
+      const keys = indexes[key].keys;
+      if (!keys || typeof keys !== 'object') return cb(new Error(
+        'the keys in your model index are not well defined! please see' +
+      'https://loopback.io/doc/en/lb3/Model-definition-JSON-file.html#indexes',
+      ));
+
+      const partitioned = indexes[key].partitioned || false;
+
+      const fields = [];
+      _.forEach(keys, function(value, key) {
+        const obj = {};
+        let order;
+        if (keys[key] === 1) order = 'asc';
+        else order = 'desc';
+        obj[key] = order;
+        fields.push(obj);
+      });
+      results[key] = {fields, partitioned};
+    }
+    return results;
+  };
+
+  /**
+ * Perform the indexes comparison for `autoupdate`.
+ * @param {Object} newIndexes
+ * newIndexes in format:
+ * ```js
+ * {
+  *   indexName: {fields: [{afield: 'asc'}], partitioned: false},
+  *   compositeIndexName: {fields: [{field1: 'asc'}, {field2: 'asc'}], partitioned: true}
+  * }
+  * ```
+  * @param {Object} oldIndexes
+  * oldIndexes in format:
+  * ```js
+  * {
+  *   indexName: {
+  *     ddoc: '_design/LBModel__Foo__LBIndex__bar_index',
+  *     fields: [{afield: 'asc'}],
+  *     partitioned: true
+  *   }
+  * }
+  * ```
+  * @callback {Function} cb The callback function
+  * @param {Object} result indexes to add and drop after comparison
+  * ```js
+  * result: {indexesToAdd: {$someIndexes}, indexesToDrop: {$someIndexes}}
+  * ```
+  */
+  Cloudant.prototype.compare = function(newIndexes, oldIndexes, cb) {
+    debug('Cloudant.prototype.compare');
+    const result = {};
+    let indexesToDrop = {};
+    let indexesToAdd = {};
+    let iAdd;
+    for (const niKey in newIndexes) {
+      if (!oldIndexes.hasOwnProperty(niKey)) {
+        // Add item to `indexesToAdd` if it's new
+        iAdd = {};
+        iAdd[niKey] = newIndexes[niKey];
+        indexesToAdd = _.merge(indexesToAdd, iAdd);
+      } else {
+        if (arrEqual(newIndexes[niKey].fields, oldIndexes[niKey].fields)) {
+          // Don't change it if index already exists
+          delete oldIndexes[niKey];
+        } else {
+          // Update index if fields change
+          iAdd = {};
+          const iDrop = {};
+          iAdd[niKey] = newIndexes[niKey];
+          indexesToAdd = _.merge(indexesToAdd, iAdd);
+        }
+
+        function arrEqual(arr1, arr2) {
+          if (!Array.isArray(arr1) || !Array.isArray(arr2)) return false;
+          let isEqual = true;
+          for (const item in arr1) {
+            const i = _.findIndex(arr2, arr1[item]);
+            isEqual = isEqual && (i > -1);
+          }
+          return isEqual;
+        }
+      }
+    }
+    indexesToDrop = oldIndexes;
+    result.indexesToAdd = indexesToAdd;
+    result.indexesToDrop = indexesToDrop;
+    debug('result for compare: %s', inspect(result, {depth: null}));
+    return result;
+  };
+
+  /**
+    * Create an index in cloudant with the configuration properties of an index body.
+    * This method is created to replace `createIndex`, which only takes in
+    * limited parameters(ddocName, indexName, fields).
+    * @param {Object} config The index config properties in format
+    * ```
+    * {
+    *   fields: Array,
+    *   ddocName: String,
+    *   indexName: String,
+    *   partitioned: Boolean,
+    *   ...otherProperties: any
+    * }
+    * ```
+    * @callback {Function} cb The callback function
+  */
+  Cloudant.prototype.createIndexWithConfig = function(config, cb) {
+    debug('createIndexWithConfig: config %s', config);
+    const self = this;
+    const indexBody = {
+      index: {
+        fields: config.fields,
+      },
+      partitioned: config.partitioned || false,
+      ddoc: config.ddocName,
+      name: config.indexName,
+      type: 'json',
+    };
+
+    const requestObject = {
+      db: self.settings.database,
+      path: '_index',
+      method: 'post',
+      body: indexBody,
+    };
+
+    self.getDriverInst().request(requestObject, cb);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "debug": "^4.1.1",
     "lodash": "^4.17.11",
     "loopback-connector": "^4.0.0",
-    "loopback-connector-couchdb2": "^1.2.0",
+    "loopback-connector-couchdb2": "^1.5.1",
     "request": "^2.81.0",
     "strong-globalize": "^5.0.0"
   },

--- a/test/partition.test.js
+++ b/test/partition.test.js
@@ -1,0 +1,168 @@
+// Copyright IBM Corp. 2016,2019. All Rights Reserved.
+// Node module: loopback-connector-cloudant
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+require('./init.js');
+const _ = require('lodash');
+const should = require('should');
+const DEFAULT_MODEL_VIEW = 'loopback__model__name';
+let Product, db, connector;
+
+const config = {
+  url: process.env.CLOUDANT_URL,
+  username: process.env.CLOUDANT_USERNAME,
+  password: process.env.CLOUDANT_PASSWORD,
+  database: process.env.CLOUDANT_PARTITIONED_DATABASE,
+  plugin: 'retry',
+  retryAttempts: 10,
+  retryTimeout: 50,
+};
+
+describe('cloudant - partitioned db', () => {
+  before(function(done) {
+    db = global.getDataSource(config);
+    connector = db.connector;
+    db.automigrate(done);
+  });
+
+  it('property level - create global index by default', (done) => {
+    Product = db.define('Product', {
+      prodName: {type: String, index: true},
+      desc: {type: String},
+    });
+    db.autoupdate('Product', (err) => {
+      if (err) return done(err);
+      connector.getIndexes(connector.getDbName(connector), (e, results) => {
+        if (e) return done(e);
+        const indexes = results.indexes;
+        const indexName = 'prodName_index';
+        should.exist(indexes);
+
+        const index = _.find(indexes, function(index) {
+          return index.name === indexName;
+        });
+        should.exist(index);
+        index.name.should.equal(indexName);
+        index.def.fields[0]['prodName'].should.equal('asc');
+        index.def.fields[1][DEFAULT_MODEL_VIEW].should.equal('asc');
+        // should be a global index
+        index.partitioned.should.equal(false);
+        done();
+      });
+    });
+  });
+
+  it('index entry - create global index by default', (done) => {
+    Product = db.define('Product', {
+      prodName: {type: String},
+      desc: {type: String},
+    }, {
+      indexes: {
+        'prodName1_index': {
+          keys: {
+            prodName: -1,
+          },
+        },
+      },
+    });
+    db.autoupdate('Product', (err) => {
+      if (err) return done(err);
+      connector.getIndexes(connector.getDbName(connector), (e, results) => {
+        if (e) return done(e);
+        const indexes = results.indexes;
+        const indexName = 'prodName1_index';
+        should.exist(indexes);
+
+        const index = _.find(indexes, function(index) {
+          return index.name === indexName;
+        });
+        should.exist(index);
+        index.name.should.equal(indexName);
+        index.def.fields[0]['prodName'].should.equal('desc');
+        index.def.fields[1][DEFAULT_MODEL_VIEW].should.equal('desc');
+        // should be a global index
+        index.partitioned.should.equal(false);
+        done();
+      });
+    });
+  });
+
+  it('index entry - ' +
+    'create partitioned index for when `partitioned` is configured as true',
+  (done) => {
+    Product = db.define('Product', {
+      prodName: {type: String},
+      desc: {type: String},
+    }, {
+      indexes: {
+        'prodName2_index': {
+          partitioned: true,
+          keys: {
+            prodName: 1,
+          },
+        },
+      },
+    });
+    db.autoupdate('Product', (err) => {
+      if (err) return done(err);
+      connector.getIndexes(connector.getDbName(connector), (e, results) => {
+        if (e) return done(e);
+        const indexes = results.indexes;
+        const indexName = 'prodName2_index';
+        should.exist(indexes);
+
+        const index = _.find(indexes, function(index) {
+          return index.name === indexName;
+        });
+        should.exist(index);
+        index.name.should.equal(indexName);
+        index.def.fields[0]['prodName'].should.equal('asc');
+        index.def.fields[1][DEFAULT_MODEL_VIEW].should.equal('asc');
+        // should be a global index
+        index.partitioned.should.equal(true);
+        done();
+      });
+    });
+  });
+
+  it('index entry - ' +
+    'create global index for when `partitioned` is configured as false',
+  (done) => {
+    Product = db.define('Product', {
+      prodName: {type: String},
+      desc: {type: String},
+    }, {
+      indexes: {
+        'prodName3_index': {
+          partitioned: false,
+          keys: {
+            prodName: 1,
+          },
+        },
+      },
+    });
+    db.automigrate('Product', (err) => {
+      if (err) return done(err);
+      connector.getIndexes(connector.getDbName(connector), (e, results) => {
+        if (e) return done(e);
+        const indexes = results.indexes;
+        const indexName = 'prodName3_index';
+        should.exist(indexes);
+
+        const index = _.find(indexes, function(index) {
+          return index.name === indexName;
+        });
+        should.exist(index);
+        index.name.should.equal(indexName);
+        index.def.fields[0]['prodName'].should.equal('asc');
+        index.def.fields[1][DEFAULT_MODEL_VIEW].should.equal('asc');
+        // should be a global index
+        index.partitioned.should.equal(false);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Description

connect to https://github.com/strongloop/loopback-connector-cloudant/issues/216
Support create partitioned index in partitioned database.

User can define the index in model config as 
```js
Product = db.define('Product', {
      prodName: {type: String},
      desc: {type: String},
    }, {
      indexes: {
        'prodName_index': {
         // Partitioned index
          partitioned: true,
          keys: {
            prodName: 1,
          },
        },
      },
    });
```
to create partitioned index.
If no `partitioned` property defined, the default index will be global. 

~TODO:~

- [x] fix lint
- [x] add jsdoc
- [x] extract util method as prototype private method
- [x] refactor couchdb2, PR https://github.com/strongloop/loopback-connector-couchdb2/pull/69 to be merged
- [x] delete dup function in cloudant

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
