### PR TITLE
fix CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # the last matching pattern has the most precedence.
 
 # Current maintainers
-* @jannyHou @b-admike @dhmlau @emonddr
+* @jannyHou @dhmlau @emonddr
 
 # Alumni maintainers
-* @kjdelisle @loay @ssh24 @virkt25 
+# @kjdelisle @loay @ssh24 @virkt25 @b-admike


### PR DESCRIPTION
### Description
Currently the alumni maintainers are at the bottom of the file, but it's prefixed with `*`.  It should be `#` so that it's not affecting the reviewer list of the PRs. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
